### PR TITLE
feat(user-docs): add stage params for static website construct

### DIFF
--- a/backend/orchestrator/package.json
+++ b/backend/orchestrator/package.json
@@ -37,7 +37,7 @@
     "@swarmion/eslint-plugin": "^0.6.0",
     "@types/jest": "^27.5.1",
     "@types/node": "^17.0.36",
-    "constructs": "^10.1.22",
+    "constructs": "^10.1.23",
     "esbuild": "^0.14.42",
     "esbuild-visualizer": "^0.3.1",
     "eslint": "^8.16.0",

--- a/packages/serverless-configuration/src/sharedConfig.ts
+++ b/packages/serverless-configuration/src/sharedConfig.ts
@@ -25,8 +25,8 @@ export const sharedProviderConfig = {
  */
 export const sharedParams = {
   dev: { profile: 'swarmion-developer' },
-  staging: { profile: 'swarmion-developer' },
-  production: { profile: 'swarmion-developer' },
+  staging: { profile: '' },
+  production: { profile: '' },
 };
 
 export const sharedEsbuildConfig = {

--- a/user-docs/cloudfront/package.json
+++ b/user-docs/cloudfront/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@serverless/typescript": "^3.18.0",
+    "@swarmion/serverless-helpers": "^0.6.0",
     "@types/jest": "^27.5.1",
     "@types/node": "^17.0.36",
     "eslint": "^8.16.0",

--- a/user-docs/cloudfront/package.json
+++ b/user-docs/cloudfront/package.json
@@ -25,7 +25,7 @@
     "eslint": "^8.16.0",
     "jest": "^27.5.1",
     "serverless": "^3.18.2",
-    "serverless-lift": "^1.17.0",
+    "serverless-lift": "^1.18.0",
     "ts-jest": "^27.1.5",
     "ts-node": "^10.8.0",
     "typescript": "^4.7.2"

--- a/user-docs/cloudfront/serverless.ts
+++ b/user-docs/cloudfront/serverless.ts
@@ -36,6 +36,9 @@ const serverlessConfiguration: AWS & Lift = {
       type: 'static-website',
       path: '../documentation/build',
       errorPage: '404.html',
+      domain: '${param:domain}',
+      redirectToMainDomain: '${param:redirectToMainDomain}',
+      certificate: '${param:certificate}',
     },
   },
   resources: {

--- a/user-docs/cloudfront/serverless.ts
+++ b/user-docs/cloudfront/serverless.ts
@@ -7,13 +7,27 @@ import {
   sharedParams,
   sharedProviderConfig,
 } from '@swarmion/serverless-configuration';
+import { mergeStageParams } from '@swarmion/serverless-helpers';
 
 const serverlessConfiguration: AWS & Lift = {
   service: `${projectName}-documentation`, // Keep it short to have role name below 64
   frameworkVersion,
   plugins: ['serverless-lift'],
   provider: sharedProviderConfig,
-  params: sharedParams,
+  params: mergeStageParams(sharedParams, {
+    dev: {
+      domain: [],
+      redirectToMainDomain: false,
+      certificate: '',
+    },
+    staging: { domain: [], redirectToMainDomain: false, certificate: '' },
+    production: {
+      domain: ['www.swarmion.dev', 'swarmion.dev'],
+      redirectToMainDomain: true,
+      certificate:
+        'arn:aws:acm:us-east-1:801673046086:certificate/fbf65a9c-2280-4895-af86-3bd180f9605c',
+    },
+  }),
   custom: {
     projectName,
   },

--- a/user-docs/cloudfront/serverless.ts
+++ b/user-docs/cloudfront/serverless.ts
@@ -41,6 +41,7 @@ const serverlessConfiguration: AWS & Lift = {
       certificate: '${param:certificate}',
     },
   },
+  lift: { automaticPermissions: false },
   resources: {
     Description: 'Documentation cloudfront service',
   },

--- a/user-docs/cloudfront/tsconfig.json
+++ b/user-docs/cloudfront/tsconfig.json
@@ -6,7 +6,8 @@
     "esModuleInterop": true
   },
   "references": [
-    { "path": "../../packages/serverless-configuration/tsconfig.build.json" }
+    { "path": "../../packages/serverless-configuration/tsconfig.build.json" },
+    { "path": "../../packages/serverless-helpers/tsconfig.build.json" }
   ],
   "include": ["./**/*.ts"],
   "ts-node": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4532,7 +4532,7 @@ __metadata:
     "@types/node": ^17.0.36
     aws-cdk-lib: ^2.26.0
     aws-sdk: ^2.1145.0
-    constructs: ^10.1.22
+    constructs: ^10.1.23
     dynamodb-toolbox: ^0.4.0-alpha.2
     esbuild: ^0.14.42
     esbuild-visualizer: ^0.3.1
@@ -4587,7 +4587,7 @@ __metadata:
     eslint: ^8.16.0
     jest: ^27.5.1
     serverless: ^3.18.2
-    serverless-lift: ^1.17.0
+    serverless-lift: ^1.18.0
     ts-jest: ^27.1.5
     ts-node: ^10.8.0
     typescript: ^4.7.2
@@ -8085,10 +8085,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"constructs@npm:^10.0.127, constructs@npm:^10.1.22":
-  version: 10.1.22
-  resolution: "constructs@npm:10.1.22"
-  checksum: 2ea44264ccd2c796bf23661e0d21bc58331b8669c285f37fcad11da7b5f1334aa7c8f48c6cf7c1edb965efdd21620d993e6dc1ae234a0d33c794775c8e1a2f9e
+"constructs@npm:^10.0.127, constructs@npm:^10.1.23":
+  version: 10.1.23
+  resolution: "constructs@npm:10.1.23"
+  checksum: a6a22028e1107680877940af0fddc2a57baed3ef0127647a3a305ab54c0e382c3403e06e7c0c2b14b270c578b7c7f7e06a279d0aa077b639cbc969a76859b06e
   languageName: node
   linkType: hard
 
@@ -18384,9 +18384,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serverless-lift@npm:^1.17.0":
-  version: 1.17.0
-  resolution: "serverless-lift@npm:1.17.0"
+"serverless-lift@npm:^1.18.0":
+  version: 1.18.0
+  resolution: "serverless-lift@npm:1.18.0"
   dependencies:
     "@aws-cdk/aws-apigatewayv2-alpha": ^2.21.1-alpha.0
     aws-cdk-lib: ^2.21.1
@@ -18403,9 +18403,10 @@ __metadata:
     pascal-case: ^3.1.2
     stripe: ^8.160.0
     toml: ^3.0.0
+    traverse: ^0.6.6
   peerDependencies:
     serverless: ^2.36.0 || ^3
-  checksum: c5105ccc1e6f0c540a91f88ce416e184dca91068f80c6abb544ce9e1464405c4b623882de965af2c5b5d388024887d58eb64d0cb7088d0901b9240edb3f9cc86
+  checksum: e1b0f3cd13c99a788c4dcdadc7c229e02429e138263fef154dedbeab10edf9a8af90f36c47cf6e47f6e91cb20bf10f17fd9b61a4468a0557642010911ee99cba
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4581,6 +4581,7 @@ __metadata:
   dependencies:
     "@serverless/typescript": ^3.18.0
     "@swarmion/serverless-configuration": ^0.6.0
+    "@swarmion/serverless-helpers": ^0.6.0
     "@types/jest": ^27.5.1
     "@types/node": ^17.0.36
     eslint: ^8.16.0


### PR DESCRIPTION
This PR add per-stage support to deploy documentation to cloudfront. The issue here is that for some environments we need empty variables and for the moment it is not possible with Serverless.

I'll check what we can do