### PR TITLE
fix(contracts): prevent using URL class to build fetch path with no base url

### DIFF
--- a/packages/serverless-contracts/src/contracts/apiGateway/__tests__/fetchRequest.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__tests__/fetchRequest.test.ts
@@ -127,4 +127,36 @@ describe('apiGateway fetch request', () => {
       );
     });
   });
+
+  describe('httpApi without base url', () => {
+    const httpApiContract = new ApiGatewayContract({
+      id: 'testContract',
+      path: '/coucou',
+      method: 'GET',
+      integrationType: 'httpApi',
+      authorizerType: undefined,
+      pathParametersSchema: undefined,
+      queryStringParametersSchema,
+      headersSchema: undefined,
+      bodySchema: undefined,
+      outputSchema: undefined,
+    });
+
+    it('should have the correct axios request ', async () => {
+      await getFetchRequest(
+        httpApiContract,
+        mockedFetch as unknown as typeof fetch,
+        {
+          queryStringParameters: {
+            testId: 'erty',
+          },
+        },
+      );
+      expect(mockedFetch).toHaveBeenCalledWith('/coucou?testId=erty', {
+        body: undefined,
+        headers: undefined,
+        method: 'GET',
+      });
+    });
+  });
 });

--- a/packages/serverless-contracts/src/contracts/apiGateway/features/fetchRequest.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/features/fetchRequest.ts
@@ -12,9 +12,16 @@ export const getFetchRequest = async <Contract extends ApiGatewayContract>(
   const { path, method, queryStringParameters, body, headers } =
     getRequestParameters<Contract>(contract, options);
 
-  const url = new URL(path, options.baseUrl);
+  let url;
+  const searchString = new URLSearchParams(queryStringParameters).toString();
 
-  url.search = new URLSearchParams(queryStringParameters).toString();
+  if (options.baseUrl !== undefined) {
+    url = new URL(path, options.baseUrl);
+
+    url.search = searchString;
+  } else {
+    url = `${path}?${searchString}`;
+  }
 
   const response = await fetchFunction(url, {
     method,


### PR DESCRIPTION
Fixes #208 
The problem came from the fact that new URL validate the url format and require it to start with http:// etc
So now, if baseUrl is not defined, we don't use the URL class and we concatenate the path and the query params manually