### PR TITLE
feat(serverless-contracts): validate whole input event

### DIFF
--- a/packages/serverless-contracts/src/contracts/apiGateway/features/httpLambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/features/httpLambdaHandler.ts
@@ -46,13 +46,11 @@ export const getHttpLambdaHandler =
 
       const parsedEvent = proxyEventToHandlerEvent<Contract>(event);
 
-      if (contract.bodySchema !== undefined) {
-        const inputValidator = ajv.compile(contract.bodySchema);
-        // @ts-ignore error on type evaluation, body is define on parsedEvent
-        if (!inputValidator(parsedEvent.body)) {
-          throw createHttpError(400, 'Invalid input');
-        }
+      const inputValidator = ajv.compile(contract.inputSchema);
+      if (!inputValidator(parsedEvent)) {
+        throw createHttpError(400, 'Invalid input');
       }
+
       const handlerResponse = await handler(parsedEvent);
 
       if (contract.outputSchema !== undefined) {

--- a/packages/serverless-contracts/src/contracts/apiGateway/types/common.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/common.ts
@@ -15,14 +15,17 @@ export type PathParametersType<Contract extends ApiGatewayContract> =
   Contract['pathParametersSchema'] extends ConstrainedJSONSchema
     ? FromSchema<Contract['pathParametersSchema']>
     : undefined;
+
 export type QueryStringParametersType<Contract extends ApiGatewayContract> =
   Contract['queryStringParametersSchema'] extends ConstrainedJSONSchema
     ? FromSchema<Contract['queryStringParametersSchema']>
     : undefined;
+
 export type HeadersType<Contract extends ApiGatewayContract> =
   Contract['headersSchema'] extends ConstrainedJSONSchema
     ? FromSchema<Contract['headersSchema']>
     : undefined;
+
 export type BodyType<Contract extends ApiGatewayContract> =
   Contract['bodySchema'] extends JSONSchema
     ? FromSchema<Contract['bodySchema']>


### PR DESCRIPTION
We currently only validate the body for an Api Gateway contract. However, we easily have the ability to validate the whole event with `contract.inputSchema`