### PR TITLE
Doc: add info on header case in http/2

### DIFF
--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
@@ -20,7 +20,7 @@ Let's create our first HttpApi contract. First we will need to define the subsch
 - then the different parts of the http request:
   - the path parameters: `pathParametersSchema`, which must correspond to a `Record<string, string>`
   - the query string parameters: `queryStringParametersSchema`, which must respect the same constraint
-  - the headers: `headersSchema`, with the same constraint
+  - the headers: `headersSchema`, with the same constraint (and as per [HTTP/2 specification](https://httpwg.org/specs/rfc7540.html#HttpHeaders), they should be lowercase)
   - the body `bodySchema` which is an unconstrained JSON schema
 - finally, the `outputSchema` in order to be able to validate the output of the lambda. It is also an unconstrained JSON schema.
 
@@ -41,8 +41,8 @@ const queryStringParametersSchema = {
 
 const headersSchema = {
   type: 'object',
-  properties: { myHeader: { type: 'string' } },
-  required: ['myHeader'],
+  properties: { 'my-header': { type: 'string' } }, // Warning: headers must be lowercase in HTTP/2
+  required: ['my-header'],
 } as const;
 
 const bodySchema = {
@@ -231,7 +231,7 @@ Simply call the `getAxiosRequest` function with the schema.
 await getAxiosRequest(myContract, axiosClient, {
   pathParameters: { userId: '15', pageNumber: '45' },
   headers: {
-    myHeader: 'hello',
+    'my-header': 'hello',
   },
   queryStringParameters: { testId: 'plop' },
   body: { foo: 'bar' },
@@ -247,7 +247,7 @@ If you want to use fetch, you can try the `getFetchRequest` function:
 await getFetchRequest(myContract, fetch, {
   pathParameters: { userId: '15', pageNumber: '45' },
   headers: {
-    myHeader: 'hello',
+    'my-header': 'hello',
   },
   queryStringParameters: { testId: 'plop' },
   body: { foo: 'bar' },
@@ -265,7 +265,7 @@ If you want to use another request client, you can use the type inference to gen
 getRequestParameters(myContract, {
   pathParameters: { userId: '15', pageNumber: '45' },
   headers: {
-    myHeader: 'hello',
+    'my-header': 'hello',
   },
   queryStringParameters: { testId: 'plop' },
   body: { foo: 'bar' },


### PR DESCRIPTION
Hey guys,

As per HTTP/2 spec, requests' headers must be lowercase. However, since type-inference is case-sensitive in typescript, we may encouter errors when having a header defined like this (with uppercase letter(s)):
![Screenshot from 2022-09-05 14-53-43](https://user-images.githubusercontent.com/16920060/188454085-def043e5-43b0-4d64-87db-d52a2381aa99.png)

Here, when using `getHttpLambdaHandler` from a contract with such headers, ajv looks for a `myHeader` key but in HTTP/2, curl defaults to lowercasing all headers which leads to a validation error.

This is just a proposition as swarmion's doc is not supposed to be about http standards, but I thought this example was a bit misleading.

