### PR TITLE
feat(serverless-contracts): add `context` and `callback` support

### DIFF
--- a/packages/serverless-contracts/src/contracts/apiGateway/__mocks__/requestContext.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__mocks__/requestContext.ts
@@ -1,6 +1,7 @@
 import {
   APIGatewayEventRequestContextV2WithAuthorizer,
   APIGatewayEventRequestContextWithAuthorizer,
+  Context,
 } from 'aws-lambda';
 
 export const getRequestContextMock = (
@@ -59,3 +60,17 @@ export const getRequestContextMockV2 = (
   timeEpoch: 0,
   ...args,
 });
+
+export const getHandlerContextMock = (args?: Partial<Context>): Context =>
+  // @ts-expect-error only partial typing here
+  ({
+    callbackWaitsForEmptyEventLoop: false,
+    functionName: '',
+    functionVersion: '',
+    invokedFunctionArn: '',
+    memoryLimitInMB: '',
+    awsRequestId: '',
+    logGroupName: '',
+    logStreamName: '',
+    ...args,
+  });

--- a/packages/serverless-contracts/src/contracts/apiGateway/__tests__/httpLambdaHandler.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__tests__/httpLambdaHandler.test.ts
@@ -9,6 +9,7 @@ import { ApiGatewayContract } from 'contracts';
 
 import { httpApiGatewayContractMock } from '../__mocks__/httpApiGatewayContract';
 import {
+  getHandlerContextMock,
   getRequestContextMock,
   getRequestContextMockV2,
 } from '../__mocks__/requestContext';
@@ -25,6 +26,7 @@ describe('apiGateway lambda handler', () => {
           ...getRequestContextMockV2(),
           authorizer: { claims: { foo: 'claimBar' } },
         };
+      const fakeContext = getHandlerContextMock();
 
       const handler: HandlerType<typeof httpApiContract> = ({
         body,
@@ -46,18 +48,25 @@ describe('apiGateway lambda handler', () => {
       };
       const httpHandler = getHttpLambdaHandler(httpApiContract)(handler);
 
-      const result = await httpHandler({
-        pathParameters: { userId: 'toto', pageNumber: '15' },
-        body: JSON.stringify({ foo: 'bar' }),
-        headers: { myHeader: 'MyCustomHeader', anotherHeader: 'anotherHeader' },
-        queryStringParameters: { testId: 'myTestId' },
-        requestContext: fakeRequestContext,
-        version: '',
-        routeKey: '',
-        rawPath: '',
-        rawQueryString: '',
-        isBase64Encoded: false,
-      });
+      const result = await httpHandler(
+        {
+          pathParameters: { userId: 'toto', pageNumber: '15' },
+          body: JSON.stringify({ foo: 'bar' }),
+          headers: {
+            myHeader: 'MyCustomHeader',
+            anotherHeader: 'anotherHeader',
+          },
+          queryStringParameters: { testId: 'myTestId' },
+          requestContext: fakeRequestContext,
+          version: '',
+          routeKey: '',
+          rawPath: '',
+          rawQueryString: '',
+          isBase64Encoded: false,
+        },
+        fakeContext,
+        () => null,
+      );
 
       expect(result).toEqual({
         body: JSON.stringify({
@@ -76,6 +85,7 @@ describe('apiGateway lambda handler', () => {
           ...getRequestContextMockV2(),
           authorizer: { claims: { foo: 'claimBar' } },
         };
+      const fakeContext = getHandlerContextMock();
 
       const handler: HandlerType<typeof httpApiContract> = ({
         body,
@@ -97,18 +107,25 @@ describe('apiGateway lambda handler', () => {
       };
       const httpHandler = getHttpLambdaHandler(httpApiContract)(handler);
 
-      const result = await httpHandler({
-        pathParameters: { userId: 'toto', pageNumber: '15' },
-        body: JSON.stringify({ foo: 'bar' }),
-        headers: { myHeader: 'MyCustomHeader', anotherHeader: 'anotherHeader' },
-        queryStringParameters: { testId: 'myTestId' },
-        requestContext: fakeRequestContext,
-        version: '',
-        routeKey: '',
-        rawPath: '',
-        rawQueryString: '',
-        isBase64Encoded: false,
-      });
+      const result = await httpHandler(
+        {
+          pathParameters: { userId: 'toto', pageNumber: '15' },
+          body: JSON.stringify({ foo: 'bar' }),
+          headers: {
+            myHeader: 'MyCustomHeader',
+            anotherHeader: 'anotherHeader',
+          },
+          queryStringParameters: { testId: 'myTestId' },
+          requestContext: fakeRequestContext,
+          version: '',
+          routeKey: '',
+          rawPath: '',
+          rawQueryString: '',
+          isBase64Encoded: false,
+        },
+        fakeContext,
+        () => null,
+      );
 
       expect(result).toEqual({
         body: 'bar15myTestIdMyCustomHeaderclaimBar',
@@ -124,6 +141,7 @@ describe('apiGateway lambda handler', () => {
           ...getRequestContextMockV2(),
           authorizer: { claims: { foo: 'claimBar' } },
         };
+      const fakeContext = getHandlerContextMock();
 
       const handler: HandlerType<typeof httpApiContract> = ({
         body,
@@ -145,18 +163,25 @@ describe('apiGateway lambda handler', () => {
       };
       const httpHandler = getHttpLambdaHandler(httpApiContract)(handler);
 
-      const result = await httpHandler({
-        pathParameters: { userId: 'toto', pageNumber: '15' },
-        body: JSON.stringify({ bar: 'foo' }),
-        headers: { myHeader: 'MyCustomHeader', anotherHeader: 'anotherHeader' },
-        queryStringParameters: { testId: 'myTestId' },
-        requestContext: fakeRequestContext,
-        version: '',
-        routeKey: '',
-        rawPath: '',
-        rawQueryString: '',
-        isBase64Encoded: false,
-      });
+      const result = await httpHandler(
+        {
+          pathParameters: { userId: 'toto', pageNumber: '15' },
+          body: JSON.stringify({ bar: 'foo' }),
+          headers: {
+            myHeader: 'MyCustomHeader',
+            anotherHeader: 'anotherHeader',
+          },
+          queryStringParameters: { testId: 'myTestId' },
+          requestContext: fakeRequestContext,
+          version: '',
+          routeKey: '',
+          rawPath: '',
+          rawQueryString: '',
+          isBase64Encoded: false,
+        },
+        fakeContext,
+        () => null,
+      );
 
       expect(result).toEqual({
         body: 'Invalid input',
@@ -172,24 +197,32 @@ describe('apiGateway lambda handler', () => {
           ...getRequestContextMockV2(),
           authorizer: { claims: { foo: 'claimBar' } },
         };
+      const fakeContext = getHandlerContextMock();
 
       const handler: HandlerType<typeof httpApiContract> = () => {
         return Promise.resolve({ id: 'hello', name: 5 as unknown as string });
       };
       const httpHandler = getHttpLambdaHandler(httpApiContract)(handler);
 
-      const result = await httpHandler({
-        pathParameters: { userId: 'toto', pageNumber: '15' },
-        body: JSON.stringify({ foo: 'bar' }),
-        headers: { myHeader: 'MyCustomHeader', anotherHeader: 'anotherHeader' },
-        queryStringParameters: { testId: 'myTestId' },
-        requestContext: fakeRequestContext,
-        version: '',
-        routeKey: '',
-        rawPath: '',
-        rawQueryString: '',
-        isBase64Encoded: false,
-      });
+      const result = await httpHandler(
+        {
+          pathParameters: { userId: 'toto', pageNumber: '15' },
+          body: JSON.stringify({ foo: 'bar' }),
+          headers: {
+            myHeader: 'MyCustomHeader',
+            anotherHeader: 'anotherHeader',
+          },
+          queryStringParameters: { testId: 'myTestId' },
+          requestContext: fakeRequestContext,
+          version: '',
+          routeKey: '',
+          rawPath: '',
+          rawQueryString: '',
+          isBase64Encoded: false,
+        },
+        fakeContext,
+        () => null,
+      );
 
       expect(result).toEqual({
         body: 'Invalid output',
@@ -223,6 +256,8 @@ describe('apiGateway lambda handler', () => {
 
       const handler: HandlerType<typeof httpApiContract> = (
         { requestContext },
+        _context,
+        _callback,
         toto: { tata: string } = { tata: 'coucou' },
       ) => {
         const name = toto.tata + requestContext.routeKey;
@@ -230,16 +265,24 @@ describe('apiGateway lambda handler', () => {
         return Promise.resolve({ name });
       };
       const httpHandler = getHttpLambdaHandler(httpApiContract)(handler);
+      const fakeContext = getHandlerContextMock();
 
-      const result = await httpHandler({
-        headers: { myHeader: 'MyCustomHeader', anotherHeader: 'anotherHeader' },
-        requestContext: fakeRequestContext,
-        version: '',
-        routeKey: fakeRequestContext.routeKey,
-        rawPath: '',
-        rawQueryString: '',
-        isBase64Encoded: false,
-      });
+      const result = await httpHandler(
+        {
+          headers: {
+            myHeader: 'MyCustomHeader',
+            anotherHeader: 'anotherHeader',
+          },
+          requestContext: fakeRequestContext,
+          version: '',
+          routeKey: fakeRequestContext.routeKey,
+          rawPath: '',
+          rawQueryString: '',
+          isBase64Encoded: false,
+        },
+        fakeContext,
+        () => null,
+      );
 
       expect(result).toEqual({
         body: '{"name":"coucoublob"}',
@@ -268,23 +311,31 @@ describe('apiGateway lambda handler', () => {
 
         return;
       };
+      const fakeContext = getHandlerContextMock();
 
       const httpHandler = getHttpLambdaHandler(restApiContract)(handler);
 
-      const result = await httpHandler({
-        pathParameters: { userId: 'toto', pageNumber: '15' },
-        body: JSON.stringify({ foo: 'bar' }),
-        headers: { myHeader: 'MyCustomHeader', anotherHeader: 'anotherHeader' },
-        queryStringParameters: { testId: 'myTestId' },
-        requestContext: getRequestContextMock(),
-        multiValueHeaders: {},
-        httpMethod: '',
-        isBase64Encoded: false,
-        path: '',
-        multiValueQueryStringParameters: null,
-        stageVariables: null,
-        resource: '',
-      });
+      const result = await httpHandler(
+        {
+          pathParameters: { userId: 'toto', pageNumber: '15' },
+          body: JSON.stringify({ foo: 'bar' }),
+          headers: {
+            myHeader: 'MyCustomHeader',
+            anotherHeader: 'anotherHeader',
+          },
+          queryStringParameters: { testId: 'myTestId' },
+          requestContext: getRequestContextMock(),
+          multiValueHeaders: {},
+          httpMethod: '',
+          isBase64Encoded: false,
+          path: '',
+          multiValueQueryStringParameters: null,
+          stageVariables: null,
+          resource: '',
+        },
+        fakeContext,
+        () => null,
+      );
 
       expect(result).toEqual({
         body: '',

--- a/packages/serverless-contracts/src/contracts/apiGateway/__tests__/httpLambdaHandler.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__tests__/httpLambdaHandler.test.ts
@@ -68,7 +68,7 @@ describe('apiGateway lambda handler', () => {
       });
     });
 
-    it('should return a error response when throwing httpEror in handler', async () => {
+    it('should return a error response when throwing httpError in handler', async () => {
       const httpApiContract = httpApiGatewayContractMock;
 
       const fakeRequestContext: APIGatewayEventRequestContextV2WithAuthorizer<APIGatewayProxyCognitoAuthorizer> =

--- a/packages/serverless-contracts/src/contracts/apiGateway/__tests__/lambdaHandler.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__tests__/lambdaHandler.test.ts
@@ -16,6 +16,7 @@ import {
   queryStringParametersSchema,
 } from '../__mocks__/httpApiGatewayContract';
 import {
+  getHandlerContextMock,
   getRequestContextMock,
   getRequestContextMockV2,
 } from '../__mocks__/requestContext';
@@ -53,14 +54,22 @@ describe('apiGateway lambda handler', () => {
         return Promise.resolve({ id: 'hello', name });
       };
       expect(getLambdaHandler(httpApiContract)(handler)).toEqual(handler);
+      const fakeContext = getHandlerContextMock();
 
-      const { id, name } = await handler({
-        pathParameters: { userId: 'toto', pageNumber: '15' },
-        body: { foo: 'bar' },
-        headers: { myHeader: 'MyCustomHeader', anotherHeader: 'anotherHeader' },
-        queryStringParameters: { testId: 'myTestId' },
-        requestContext: fakeRequestContext,
-      });
+      const { id, name } = await handler(
+        {
+          pathParameters: { userId: 'toto', pageNumber: '15' },
+          body: { foo: 'bar' },
+          headers: {
+            myHeader: 'MyCustomHeader',
+            anotherHeader: 'anotherHeader',
+          },
+          queryStringParameters: { testId: 'myTestId' },
+          requestContext: fakeRequestContext,
+        },
+        fakeContext,
+        () => null,
+      );
 
       expect(id).toBe('hello');
       expect(name).toBe('bar15myTestIdMyCustomHeaderclaimBar');
@@ -89,6 +98,7 @@ describe('apiGateway lambda handler', () => {
             jwt: { claims: { foo: 'claimBar' }, scopes: ['profile'] },
           },
         };
+      const fakeContext = getHandlerContextMock();
 
       const handler: HandlerType<typeof httpApiContract> = ({
         body,
@@ -110,13 +120,20 @@ describe('apiGateway lambda handler', () => {
       };
       expect(getLambdaHandler(httpApiContract)(handler)).toEqual(handler);
 
-      const { id, name } = await handler({
-        pathParameters: { userId: 'toto', pageNumber: '15' },
-        body: { foo: 'bar' },
-        headers: { myHeader: 'MyCustomHeader', anotherHeader: 'anotherHeader' },
-        queryStringParameters: { testId: 'myTestId' },
-        requestContext: fakeRequestContext,
-      });
+      const { id, name } = await handler(
+        {
+          pathParameters: { userId: 'toto', pageNumber: '15' },
+          body: { foo: 'bar' },
+          headers: {
+            myHeader: 'MyCustomHeader',
+            anotherHeader: 'anotherHeader',
+          },
+          queryStringParameters: { testId: 'myTestId' },
+          requestContext: fakeRequestContext,
+        },
+        fakeContext,
+        () => null,
+      );
 
       expect(id).toBe('hello');
       expect(name).toBe('bar15myTestIdMyCustomHeaderclaimBar');
@@ -148,6 +165,7 @@ describe('apiGateway lambda handler', () => {
           lambda: { foo: 'claimBar' },
         },
       };
+      const fakeContext = getHandlerContextMock();
 
       const handler: HandlerType<typeof httpApiContract> = ({
         body,
@@ -170,13 +188,20 @@ describe('apiGateway lambda handler', () => {
       };
       expect(getLambdaHandler(httpApiContract)(handler)).toEqual(handler);
 
-      const { id, name } = await handler({
-        pathParameters: { userId: 'toto', pageNumber: '15' },
-        body: { foo: 'bar' },
-        headers: { myHeader: 'MyCustomHeader', anotherHeader: 'anotherHeader' },
-        queryStringParameters: { testId: 'myTestId' },
-        requestContext: fakeRequestContext,
-      });
+      const { id, name } = await handler(
+        {
+          pathParameters: { userId: 'toto', pageNumber: '15' },
+          body: { foo: 'bar' },
+          headers: {
+            myHeader: 'MyCustomHeader',
+            anotherHeader: 'anotherHeader',
+          },
+          queryStringParameters: { testId: 'myTestId' },
+          requestContext: fakeRequestContext,
+        },
+        fakeContext,
+        () => null,
+      );
 
       expect(id).toBe('hello');
       expect(name).toBe('bar15myTestIdMyCustomHeaderclaimBar');
@@ -207,11 +232,17 @@ describe('apiGateway lambda handler', () => {
       // @ts-expect-error we don't want to generate a full event here
       const fakeRequestContext: APIGatewayEventRequestContextWithAuthorizer<undefined> =
         {};
+      const fakeContext = getHandlerContextMock();
+
       expect(
-        await handler({
-          body: { foo: 'bar' },
-          requestContext: fakeRequestContext,
-        }),
+        await handler(
+          {
+            body: { foo: 'bar' },
+            requestContext: fakeRequestContext,
+          },
+          fakeContext,
+          () => null,
+        ),
       ).toBe(undefined);
     });
 
@@ -224,12 +255,17 @@ describe('apiGateway lambda handler', () => {
         return Promise.resolve(undefinedAuthorizer);
       };
       expect(getLambdaHandler(restApiContract)(handler)).toEqual(handler);
+      const fakeContext = getHandlerContextMock();
 
       expect(
-        await handler({
-          body: { foo: 'bar' },
-          requestContext: getRequestContextMock(),
-        }),
+        await handler(
+          {
+            body: { foo: 'bar' },
+            requestContext: getRequestContextMock(),
+          },
+          fakeContext,
+          () => null,
+        ),
       ).toBe(undefined);
     });
   });

--- a/packages/serverless-contracts/src/contracts/apiGateway/features/httpLambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/features/httpLambdaHandler.ts
@@ -40,7 +40,7 @@ const handlerResponseToLambdaResult = <Contract extends ApiGatewayContract>(
 export const getHttpLambdaHandler =
   <Contract extends ApiGatewayContract>(contract: Contract) =>
   (handler: HandlerType<Contract>): CompleteHandlerType<Contract> =>
-  async event => {
+  async (event, context, callback) => {
     try {
       const ajv = new Ajv();
 
@@ -51,7 +51,7 @@ export const getHttpLambdaHandler =
         throw createHttpError(400, 'Invalid input');
       }
 
-      const handlerResponse = await handler(parsedEvent);
+      const handlerResponse = await handler(parsedEvent, context, callback);
 
       if (contract.outputSchema !== undefined) {
         const outputValidator = ajv.compile(contract.outputSchema);

--- a/packages/serverless-contracts/src/contracts/apiGateway/types/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/lambdaHandler.ts
@@ -58,8 +58,13 @@ export type HandlerEventType<Contract extends ApiGatewayContract> =
       >
     >;
 
+/**
+ * The type of a Swarmion handler, with type-inferred event
+ * The handler function can define additional arguments
+ */
 export type HandlerType<Contract extends ApiGatewayContract> = (
   event: HandlerEventType<Contract>,
+  ...additionalArgs: never[]
 ) => Promise<OutputType<Contract>>;
 
 export type LambdaEventType<Contract extends ApiGatewayContract> =

--- a/packages/serverless-contracts/src/contracts/apiGateway/types/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/lambdaHandler.ts
@@ -3,11 +3,14 @@ import type {
   APIGatewayEventRequestContextLambdaAuthorizer,
   APIGatewayEventRequestContextV2WithAuthorizer,
   APIGatewayEventRequestContextWithAuthorizer,
+  APIGatewayProxyCallback,
+  APIGatewayProxyCallbackV2,
   APIGatewayProxyCognitoAuthorizer,
   APIGatewayProxyEventBase,
   APIGatewayProxyEventV2WithRequestContext,
   APIGatewayProxyResult,
   APIGatewayProxyResultV2,
+  Context,
 } from 'aws-lambda';
 import { FromSchema } from 'json-schema-to-ts';
 
@@ -58,12 +61,19 @@ export type HandlerEventType<Contract extends ApiGatewayContract> =
       >
     >;
 
+type HandlerCallbackType<Contract extends ApiGatewayContract> =
+  Contract['integrationType'] extends 'restApi'
+    ? APIGatewayProxyCallback
+    : APIGatewayProxyCallbackV2;
+
 /**
  * The type of a Swarmion handler, with type-inferred event
  * The handler function can define additional arguments
  */
 export type HandlerType<Contract extends ApiGatewayContract> = (
   event: HandlerEventType<Contract>,
+  context: Context,
+  callback: HandlerCallbackType<Contract>,
   ...additionalArgs: never[]
 ) => Promise<OutputType<Contract>>;
 
@@ -83,4 +93,6 @@ export type LambdaReturnType<Contract extends ApiGatewayContract> =
 
 export type CompleteHandlerType<Contract extends ApiGatewayContract> = (
   event: LambdaEventType<Contract>,
+  context: Context,
+  callback: HandlerCallbackType<Contract>,
 ) => Promise<LambdaReturnType<Contract>>;

--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
@@ -205,35 +205,6 @@ const handler = getLambdaHandler(myContract)(async event => {
 });
 ```
 
-You can also pass additional arguments to the handler, but keep in mind that you will need to provide default values as Lambda will not pass them for you. Also bear in mind that lambda passes `context` and `callback` to your lambda, so any additional argument **MUST** be after. See https://docs.aws.amazon.com/lambda/latest/dg/typescript-handler.html.
-
-```ts
-interface AdditionalArgs {
-  toto: string;
-}
-
-const additionalArgs = {
-  toto: 'tata',
-};
-
-const handler = getLambdaHandler(myContract)(
-  async (
-    event, // type will be properly inferred
-    _context, // be careful to define these arguments even if you don't use them!
-    _callback,
-    myAdditionalArg: AdditionalArgs = additionalArgs, // here you need to manually define a default
-  ) => {
-    event.pathParameters.userId; // will have type 'string'
-    event.requestContext.authorizer.claims.sub; // will have type 'string' if authorizerType is "cognito", otherwise will fail
-
-    event.toto; // will fail typing
-    event.pathParameters.toto; // will also fail
-
-    return { id: 'coucou', name: 'coucou' }; // also type-safe!
-  },
-);
-```
-
 ### Serialization/deserialization and input/output validation at runtime
 
 If you use your lambda as an ApiGateway integration, you will need to use middlewares to parse the body, validate the input and output formats and serialize the output body. You may also need to handler error cases with specific http status codes.

--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
@@ -205,6 +205,33 @@ const handler = getLambdaHandler(myContract)(async event => {
 });
 ```
 
+You can also pass additional arguments to the handler, but keep in mind that you will need to provide default values as Lambda will not pass them for you.
+
+```ts
+interface AdditionalArgs {
+  toto: string;
+}
+
+const additionalArgs = {
+  toto: 'tata',
+};
+
+const handler = getLambdaHandler(myContract)(
+  async (
+    event, // type will be properly inferred
+    myAdditionalArg: AdditionalArgs = additionalArgs, // here you need to manually define a default
+  ) => {
+    event.pathParameters.userId; // will have type 'string'
+    event.requestContext.authorizer.claims.sub; // will have type 'string' if authorizerType is "cognito", otherwise will fail
+
+    event.toto; // will fail typing
+    event.pathParameters.toto; // will also fail
+
+    return { id: 'coucou', name: 'coucou' }; // also type-safe!
+  },
+);
+```
+
 ### Serialization/deserialization and input/output validation at runtime
 
 If you use your lambda as an ApiGateway integration, you will need to use middlewares to parse the body, validate the input and output formats and serialize the output body. You may also need to handler error cases with specific http status codes.

--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
@@ -205,7 +205,7 @@ const handler = getLambdaHandler(myContract)(async event => {
 });
 ```
 
-You can also pass additional arguments to the handler, but keep in mind that you will need to provide default values as Lambda will not pass them for you.
+You can also pass additional arguments to the handler, but keep in mind that you will need to provide default values as Lambda will not pass them for you. Also bear in mind that lambda passes `context` and `callback` to your lambda, so any additional argument **MUST** be after. See https://docs.aws.amazon.com/lambda/latest/dg/typescript-handler.html.
 
 ```ts
 interface AdditionalArgs {
@@ -219,6 +219,8 @@ const additionalArgs = {
 const handler = getLambdaHandler(myContract)(
   async (
     event, // type will be properly inferred
+    _context, // be careful to define these arguments even if you don't use them!
+    _callback,
     myAdditionalArg: AdditionalArgs = additionalArgs, // here you need to manually define a default
   ) => {
     event.pathParameters.userId; // will have type 'string'


### PR DESCRIPTION
In order to make my lambdas completly functional, I would need to pass additional arguments to my lambda handler other than the event (for example using the initialisation context of the lambda). This is currently not possible.

The desired behavior is:
```ts
const handler = getHttpLambdaHandler(myContract)(async (
      event, // type inference is ok
      toto = "tata" // with a default value
   ) => {
     // handler body
   }
);
```

This PR adds this possibility and documents it