### PR TITLE
feat(serverless-contracts): add Content-Type header to getHandler response

### DIFF
--- a/packages/create-swarmion-app/package.json
+++ b/packages/create-swarmion-app/package.json
@@ -4,8 +4,8 @@
   "version": "0.10.1",
   "contributors": [
     "MaximeVivier",
-    "guillaumeduboc",
-    "Sc0ra"
+    "Sc0ra",
+    "guillaumeduboc"
   ],
   "license": "MIT",
   "homepage": "https://www.swarmion.dev",

--- a/packages/serverless-contracts/src/contracts/apiGateway/__tests__/httpLambdaHandler.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__tests__/httpLambdaHandler.test.ts
@@ -74,6 +74,7 @@ describe('apiGateway lambda handler', () => {
           name: 'bar15myTestIdMyCustomHeaderclaimBar',
         }),
         statusCode: 200,
+        headers: { 'Content-Type': 'application/json' },
       });
     });
 
@@ -286,6 +287,7 @@ describe('apiGateway lambda handler', () => {
       expect(result).toEqual({
         body: '{"name":"coucoublob"}',
         statusCode: 200,
+        headers: { 'Content-Type': 'application/json' },
       });
     });
   });
@@ -336,7 +338,7 @@ describe('apiGateway lambda handler', () => {
         () => null,
       );
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         body: '',
         statusCode: 200,
       });

--- a/packages/serverless-contracts/src/contracts/apiGateway/utils/apiGatewayProxyTransformers.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/utils/apiGatewayProxyTransformers.ts
@@ -32,4 +32,8 @@ export const handlerResponseToProxyResult = <
 ): ApiGatewayResult<Contract> => ({
   statusCode: 200,
   body: handlerResponse !== undefined ? JSON.stringify(handlerResponse) : '',
+  headers:
+    handlerResponse !== undefined
+      ? { 'Content-Type': 'application/json' }
+      : undefined,
 });


### PR DESCRIPTION
Fixes #278 