### PR TITLE
fix: add undefined queryStringParameters values management in getFetchRequest

### DIFF
--- a/packages/serverless-contracts/src/contracts/apiGateway/__tests__/fetchRequest.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__tests__/fetchRequest.test.ts
@@ -21,7 +21,10 @@ describe('apiGateway fetch request', () => {
 
   const queryStringParametersSchema = {
     type: 'object',
-    properties: { testId: { type: 'string' } },
+    properties: {
+      testId: { type: 'string' },
+      optionalParam: { type: 'string' },
+    },
     required: ['testId'],
     additionalProperties: false,
   } as const;
@@ -64,7 +67,40 @@ describe('apiGateway fetch request', () => {
       outputSchema,
     });
 
-    it('should have the correct axiosRequest', async () => {
+    it('should have the correct axiosRequest when all values are defined', async () => {
+      await getFetchRequest(
+        httpApiContract,
+        mockedFetch as unknown as typeof fetch,
+        {
+          pathParameters: {
+            userId: 'azer',
+            pageNumber: 'zert',
+          },
+          queryStringParameters: {
+            testId: 'er',
+            optionalParam: 'ty',
+          },
+          headers: {
+            myHeader: 'rtyu',
+          },
+          body: {
+            foo: 'tyui',
+            bar: ['yuio'],
+          },
+          baseUrl: 'http://localhost:3000',
+        },
+      );
+      expect(mockedFetch).toHaveBeenCalledWith(
+        new URL('http://localhost:3000/users/azer?testId=er&optionalParam=ty'),
+        {
+          body: '{"foo":"tyui","bar":["yuio"]}',
+          headers: { myHeader: 'rtyu' },
+          method: 'POST',
+        },
+      );
+    });
+
+    it('should have the correct axiosRequest when some queryStringParameters are undefined', async () => {
       await getFetchRequest(
         httpApiContract,
         mockedFetch as unknown as typeof fetch,
@@ -75,6 +111,7 @@ describe('apiGateway fetch request', () => {
           },
           queryStringParameters: {
             testId: 'erty',
+            optionalParam: undefined,
           },
           headers: {
             myHeader: 'rtyu',

--- a/packages/serverless-contracts/src/contracts/apiGateway/features/requestParameters.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/features/requestParameters.ts
@@ -14,7 +14,7 @@ export const getRequestParameters = <Contract extends ApiGatewayContract>(
   const { pathParameters, queryStringParameters, headers, body } =
     requestArguments as {
       pathParameters: Record<string, string>;
-      queryStringParameters: Record<string, string>;
+      queryStringParameters: Record<string, string | undefined>;
       headers: Record<string, string>;
       body: BodyType<Contract>;
     };
@@ -29,7 +29,10 @@ export const getRequestParameters = <Contract extends ApiGatewayContract>(
       method: contract.method,
       path,
       body,
-      queryStringParameters,
+      queryStringParameters: omitBy(
+        queryStringParameters,
+        isUndefined,
+      ) as Record<string, string>,
       headers,
     },
     isUndefined,


### PR DESCRIPTION
This adds management of undefined queryStringParameters values in getFetchRequest and resolves #271 