### PR TITLE
fix(serverless): rename unused custom property projectName

### DIFF
--- a/backend/orchestrator/serverless.ts
+++ b/backend/orchestrator/serverless.ts
@@ -36,7 +36,6 @@ const serverlessConfiguration: AWS &
   functions,
   package: { individually: true },
   custom: {
-    projectName,
     esbuild: sharedEsbuildConfig,
   },
   contracts: {

--- a/examples/swarmion-full-stack/backend/core/serverless.ts
+++ b/examples/swarmion-full-stack/backend/core/serverless.ts
@@ -45,7 +45,6 @@ const serverlessConfiguration: AWS = {
     },
   }),
   custom: {
-    projectName,
     esbuild: sharedEsbuildConfig,
   },
   resources: {

--- a/examples/swarmion-full-stack/backend/users/serverless.ts
+++ b/examples/swarmion-full-stack/backend/users/serverless.ts
@@ -26,7 +26,6 @@ const serverlessConfiguration: AWS = {
   functions,
   package: { individually: true },
   custom: {
-    projectName,
     esbuild: sharedEsbuildConfig,
   },
   resources: {

--- a/examples/swarmion-full-stack/frontend/cloudfront/serverless.ts
+++ b/examples/swarmion-full-stack/frontend/cloudfront/serverless.ts
@@ -14,9 +14,6 @@ const serverlessConfiguration: AWS & Lift = {
   plugins: ['serverless-lift'],
   provider: sharedProviderConfig,
   params: sharedParams,
-  custom: {
-    projectName,
-  },
   constructs: {
     app: {
       type: 'static-website',

--- a/examples/swarmion-starter/backend/core/serverless.ts
+++ b/examples/swarmion-starter/backend/core/serverless.ts
@@ -45,7 +45,6 @@ const serverlessConfiguration: AWS = {
     },
   }),
   custom: {
-    projectName,
     esbuild: sharedEsbuildConfig,
   },
   resources: {

--- a/packages/nx-plugin/src/generators/service/files/serverless.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/service/files/serverless.ts__tmpl__
@@ -26,7 +26,6 @@ const serverlessConfiguration: AWS = {
   functions,
   package: { individually: true },
   custom: {
-    projectName,
     esbuild: sharedEsbuildConfig,
   },
   resources: {

--- a/user-docs/cloudfront/serverless.ts
+++ b/user-docs/cloudfront/serverless.ts
@@ -28,9 +28,6 @@ const serverlessConfiguration: AWS & Lift = {
         'arn:aws:acm:us-east-1:801673046086:certificate/fbf65a9c-2280-4895-af86-3bd180f9605c',
     },
   }),
-  custom: {
-    projectName,
-  },
   constructs: {
     app: {
       type: 'static-website',


### PR DESCRIPTION
This property is unsused and may confuse users, especially since the use of the `custom` key is not recommended (although `serverless-esbuild` uses it :/