### PR TITLE
feat: allow undefined query string paramters when all keys are optionals

### DIFF
--- a/packages/serverless-contracts/src/contracts/apiGateway/apiGatewayContract.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/apiGatewayContract.ts
@@ -117,11 +117,18 @@ export class ApiGatewayContract<
       isUndefined,
     );
 
+    const propertyKeys = Object.keys(properties);
+
+    const required =
+      this.queryStringParametersSchema?.required === undefined
+        ? propertyKeys.filter(key => key !== 'queryStringParameters')
+        : propertyKeys;
+
     return {
       type: 'object',
       properties,
       // @ts-ignore here object.keys is not precise enough
-      required: Object.keys(properties),
+      required,
       additionalProperties: true,
     };
   }

--- a/packages/serverless-contracts/src/contracts/apiGateway/types/input.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/input.ts
@@ -21,6 +21,30 @@ type AllInputProperties<
 };
 
 /**
+ * The intermediary type used to determine the required keys in the input type of the lambda.
+ *
+ * It is used to make query string parameters key optional if all its keys are optional.
+ */
+type RequiredInputSchemaProperties<
+  PathParametersSchema extends JSONSchema | undefined,
+  QueryStringParametersSchema extends JSONSchema | undefined,
+  HeadersSchema extends JSONSchema | undefined,
+  BodySchema extends JSONSchema | undefined,
+  DefinedInputProperties = DefinedProperties<
+    AllInputProperties<
+      PathParametersSchema,
+      QueryStringParametersSchema,
+      HeadersSchema,
+      BodySchema
+    >
+  >,
+> = Array<
+  QueryStringParametersSchema extends { required: readonly string[] }
+    ? keyof DefinedInputProperties
+    : Exclude<keyof DefinedInputProperties, 'queryStringParameters'>
+>;
+
+/**
  * Computed schema type of the input validation schema.
  *
  * Can be used with `FromSchema` to infer the type of the input event of the lambda
@@ -42,6 +66,12 @@ export type InputSchemaType<
 > = {
   type: 'object';
   properties: DefinedInputProperties;
-  required: Array<keyof DefinedInputProperties>;
+  required: RequiredInputSchemaProperties<
+    PathParametersSchema,
+    QueryStringParametersSchema,
+    HeadersSchema,
+    BodySchema,
+    DefinedInputProperties
+  >;
   additionalProperties: AllowAdditionalProperties;
 };


### PR DESCRIPTION
Fix #307