### PR TITLE
fix mui import in muiTheme.ts

### DIFF
--- a/examples/swarmion-full-stack/frontend/app/src/theme/muiTheme.ts
+++ b/examples/swarmion-full-stack/frontend/app/src/theme/muiTheme.ts
@@ -1,5 +1,5 @@
 import '@mui/lab/themeAugmentation';
-import { createTheme, ThemeOptions } from '@mui/material/styles';
+import { createTheme, ThemeOptions } from '@mui/material';
 
 import { UNIT } from './helpers';
 import { MuiButtonOverrides } from './overrides';


### PR DESCRIPTION
## Problem

A weird `createTheme_default is not a function` appears when importing `createTheme` from `@mui/material/styles`.

The problem is known by the community and has a simple fix, which is in this PR

## Links
- Issue on material-ui repo : https://github.com/mui/material-ui/issues/31835
  - (N.B.: OP thinks this is an "issue with esbuild" but it is also reproducible with vite)
- Comment suggesting fix : https://github.com/mui/material-ui/issues/31835#issuecomment-1147055123

I checked that there is no other such import in the swarmion repo.