### PR TITLE
feat(serverless-helpers): add getCdkhandlerPath

### DIFF
--- a/packages/serverless-helpers/src/helpers/__tests__/mergeStageParams.test.ts
+++ b/packages/serverless-helpers/src/helpers/__tests__/mergeStageParams.test.ts
@@ -1,4 +1,4 @@
-import mergeStageParams from '../mergeStageParams';
+import { mergeStageParams } from '../mergeStageParams';
 
 describe('mergeStageParams', () => {
   it('should merge single stage params', () => {

--- a/packages/serverless-helpers/src/helpers/applyHttpMiddlewares.ts
+++ b/packages/serverless-helpers/src/helpers/applyHttpMiddlewares.ts
@@ -10,7 +10,7 @@ interface Options {
   outputSchema?: JSONSchema;
 }
 
-const applyHttpMiddlewares = <Event, Result>(
+export const applyHttpMiddlewares = <Event, Result>(
   handler: Handler<Event, Result>,
   { inputSchema, outputSchema }: Options,
 ): middy.MiddyfiedHandler<Event, Result> => {
@@ -23,5 +23,3 @@ const applyHttpMiddlewares = <Event, Result>(
 
   return middyfiedHandler;
 };
-
-export default applyHttpMiddlewares;

--- a/packages/serverless-helpers/src/helpers/getCdkHandlerPath.ts
+++ b/packages/serverless-helpers/src/helpers/getCdkHandlerPath.ts
@@ -1,0 +1,6 @@
+/** Helper to be used in CDK config.ts files to retrieve the path of the handler. */
+export const getCdkHandlerPath = (directoryPath: string): string => {
+  const processRunLocation = process.cwd();
+
+  return directoryPath.replace(processRunLocation + '/', '') + '/handler.ts';
+};

--- a/packages/serverless-helpers/src/helpers/getEnvVariable.ts
+++ b/packages/serverless-helpers/src/helpers/getEnvVariable.ts
@@ -1,9 +1,7 @@
-const getEnvVariable = (name: string): string => {
+export const getEnvVariable = (name: string): string => {
   const variable = process.env[name];
   if (variable === undefined)
     throw new Error(`Environment variable not found: ${name}`);
 
   return variable;
 };
-
-export default getEnvVariable;

--- a/packages/serverless-helpers/src/helpers/getHandlerPath.ts
+++ b/packages/serverless-helpers/src/helpers/getHandlerPath.ts
@@ -1,8 +1,6 @@
 /** Helper to be used in config.ts files to retrieve the path of the handler. */
-const getHandlerPath = (directoryPath: string): string => {
+export const getHandlerPath = (directoryPath: string): string => {
   const processRunLocation = process.cwd();
 
   return directoryPath.replace(processRunLocation + '/', '') + '/handler.main';
 };
-
-export default getHandlerPath;

--- a/packages/serverless-helpers/src/helpers/index.ts
+++ b/packages/serverless-helpers/src/helpers/index.ts
@@ -1,5 +1,6 @@
-export { default as applyHttpMiddlewares } from './applyHttpMiddlewares';
-export { default as getEnvVariable } from './getEnvVariable';
-export { default as getHandlerPath } from './getHandlerPath';
-export { default as testFunctionNames } from './testFunctionNames';
-export { default as mergeStageParams } from './mergeStageParams';
+export { applyHttpMiddlewares } from './applyHttpMiddlewares';
+export { getEnvVariable } from './getEnvVariable';
+export { getHandlerPath } from './getHandlerPath';
+export { testFunctionNames } from './testFunctionNames';
+export { mergeStageParams } from './mergeStageParams';
+export { getCdkHandlerPath } from './getCdkHandlerPath';

--- a/packages/serverless-helpers/src/helpers/mergeStageParams.ts
+++ b/packages/serverless-helpers/src/helpers/mergeStageParams.ts
@@ -1,4 +1,4 @@
-const mergeStageParams = <
+export const mergeStageParams = <
   Stage extends string,
   CommonParamKeys extends string,
   ServiceParamKeys extends string,
@@ -16,5 +16,3 @@ const mergeStageParams = <
     {} as Record<Stage, Record<CommonParamKeys & ServiceParamKeys, unknown>>,
   );
 };
-
-export default mergeStageParams;

--- a/packages/serverless-helpers/src/helpers/testFunctionNames.ts
+++ b/packages/serverless-helpers/src/helpers/testFunctionNames.ts
@@ -17,7 +17,7 @@ const getFullFunctionName = (config: AWS, functionName: string): string =>
  *
  * @param config serverless configuration object
  */
-const testFunctionNames = (config: AWS): void => {
+export const testFunctionNames = (config: AWS): void => {
   const functionNames = getFunctionNames(config);
   if (functionNames.length === 0) {
     it('has no functions declared', () => {
@@ -38,5 +38,3 @@ const testFunctionNames = (config: AWS): void => {
     },
   );
 };
-
-export default testFunctionNames;


### PR DESCRIPTION
We currently have a `getHandlerPath` that works for the Serverless Framework. However the CDK requires the file to have the `ts` extension and not the handler name.

This PR adds this feature.

It may be used as such:
```
const myLambda = new NodejsFunction(this, 'Lambda', {
  entry: getCdkHandlerPath(__dirname),
  handler: 'main',
  runtime: Runtime.NODEJS_16_X,
  architecture: Architecture.ARM_64,
  awsSdkConnectionReuse: true,
  bundling: sharedEsbuildConfig,
  environment: {
    ...
  },
});
```