### PR TITLE
fix pnpm clean loop in package.json

### DIFF
--- a/packages/nx-plugin/src/generators/library/typed-json-config/package.json.ts
+++ b/packages/nx-plugin/src/generators/library/typed-json-config/package.json.ts
@@ -11,7 +11,7 @@ export const packageJson = (options: NormalizedSchema): PackageJson => ({
   module: 'dist/esm/index.js',
   types: 'dist/types/index.d.ts',
   scripts: {
-    clean: 'pnpm clean',
+    clean: 'rimraf dist',
     'lint-fix': 'pnpm linter-base-config --fix',
     'lint-fix-all': 'pnpm lint-fix .',
     'linter-base-config': 'eslint --ext=js,ts',


### PR DESCRIPTION
Basically, if you have this in your package.json:

```javascript
{
 ...
  "clean": "pnpm clean"
  // or
  "clean": "yarn clean"
 ...
}
```
Launching the clean command will loop forever and crash your computer. This PR fixes exactly that :)