### PR TITLE
Make @aws-skd/client-eventbridge a dependency of @swarmion/serverless-contracts

### DIFF
--- a/packages/serverless-contracts/package.json
+++ b/packages/serverless-contracts/package.json
@@ -41,13 +41,13 @@
     "watch": "pnpm clean && concurrently 'pnpm:package-* --watch'"
   },
   "dependencies": {
+    "@aws-sdk/client-eventbridge": "^3.188.0",
     "@babel/runtime": "^7.19.4",
     "ajv": "^8.11.0",
     "http-errors": "^2.0.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@aws-sdk/client-eventbridge": "^3.188.0",
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.19.3",
     "@babel/plugin-transform-runtime": "^7.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,12 +456,12 @@ importers:
       vite-tsconfig-paths: ^3.5.1
       vitest: ^0.23.4
     dependencies:
+      '@aws-sdk/client-eventbridge': 3.196.0
       '@babel/runtime': 7.19.4
       ajv: 8.11.0
       http-errors: 2.0.0
       lodash: 4.17.21
     devDependencies:
-      '@aws-sdk/client-eventbridge': 3.196.0
       '@babel/cli': 7.19.3_@babel+core@7.19.3
       '@babel/core': 7.19.3
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.19.3
@@ -867,6 +867,7 @@ packages:
     resolution: {integrity: sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==}
     dependencies:
       tslib: 1.14.1
+    dev: false
 
   /@aws-crypto/sha256-browser/2.0.0:
     resolution: {integrity: sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==}
@@ -879,6 +880,7 @@ packages:
       '@aws-sdk/util-locate-window': 3.188.0
       '@aws-sdk/util-utf8-browser': 3.188.0
       tslib: 1.14.1
+    dev: false
 
   /@aws-crypto/sha256-js/2.0.0:
     resolution: {integrity: sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==}
@@ -886,11 +888,13 @@ packages:
       '@aws-crypto/util': 2.0.2
       '@aws-sdk/types': 3.193.0
       tslib: 1.14.1
+    dev: false
 
   /@aws-crypto/supports-web-crypto/2.0.2:
     resolution: {integrity: sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==}
     dependencies:
       tslib: 1.14.1
+    dev: false
 
   /@aws-crypto/util/2.0.2:
     resolution: {integrity: sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==}
@@ -898,6 +902,7 @@ packages:
       '@aws-sdk/types': 3.193.0
       '@aws-sdk/util-utf8-browser': 3.188.0
       tslib: 1.14.1
+    dev: false
 
   /@aws-sdk/abort-controller/3.193.0:
     resolution: {integrity: sha512-MYPBm5PWyKP+Tq37mKs5wDbyAyVMocF5iYmx738LYXBSj8A1V4LTFrvfd4U16BRC/sM0DYB9fBFJUQ9ISFRVYw==}
@@ -905,6 +910,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/client-eventbridge/3.196.0:
     resolution: {integrity: sha512-6uoVts3Yoo9MFt2EPiRZNfEMAx/Uv3h/ScJzHUZddaxNAWKNsv++22U0EzFNDWKuIn7swWV2HskEO5X4EIJzrw==}
@@ -950,6 +956,7 @@ packages:
     transitivePeerDependencies:
       - '@aws-sdk/signature-v4-crt'
       - aws-crt
+    dev: false
 
   /@aws-sdk/client-sso/3.196.0:
     resolution: {integrity: sha512-u+UnxrVHLjLDdfCZft1AuyIhyv+77/inCHR4LcKsGASRA+jAg3z+OY+B7Q9hWHNcVt5ECMw7rxe4jA9BLf42sw==}
@@ -990,6 +997,7 @@ packages:
       tslib: 2.4.0
     transitivePeerDependencies:
       - aws-crt
+    dev: false
 
   /@aws-sdk/client-sts/3.196.0:
     resolution: {integrity: sha512-ChzK8606CugwnRLm7iwerXzeMqOsjGLe3j1j1HtQShzXZu4/ysQ3mUBBPAt2Lltx+1ep8MoI9vaQVyfw5h35ww==}
@@ -1034,6 +1042,7 @@ packages:
       tslib: 2.4.0
     transitivePeerDependencies:
       - aws-crt
+    dev: false
 
   /@aws-sdk/config-resolver/3.193.0:
     resolution: {integrity: sha512-HIjuv2A1glgkXy9g/A8bfsiz3jTFaRbwGZheoHFZod6iEQQEbbeAsBe3u2AZyzOrVLgs8lOvBtgU8XKSJWjDkw==}
@@ -1044,6 +1053,7 @@ packages:
       '@aws-sdk/util-config-provider': 3.188.0
       '@aws-sdk/util-middleware': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/credential-provider-env/3.193.0:
     resolution: {integrity: sha512-pRqZoIaqCdWB4JJdR6DqDn3u+CwKJchwiCPnRtChwC8KXCMkT4njq9J1bWG3imYeTxP/G06O1PDONEuD4pPtNQ==}
@@ -1052,6 +1062,7 @@ packages:
       '@aws-sdk/property-provider': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/credential-provider-imds/3.193.0:
     resolution: {integrity: sha512-jC7uT7uVpO/iitz49toHMGFKXQ2igWQQG2SKirREqDRaz5HSXwEP1V3rcOlNNyGIBPMggDjZnxYgJHqBXSq9Ag==}
@@ -1062,6 +1073,7 @@ packages:
       '@aws-sdk/types': 3.193.0
       '@aws-sdk/url-parser': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/credential-provider-ini/3.196.0:
     resolution: {integrity: sha512-3lL+YLBQ9KwQxG4AdRm4u2cvBNZeBmS/i3BWnCPomg96lNGPMrTEloVaVEpnrzOff6sgFxRtjkbLkVxmdipIrw==}
@@ -1077,6 +1089,7 @@ packages:
       tslib: 2.4.0
     transitivePeerDependencies:
       - aws-crt
+    dev: false
 
   /@aws-sdk/credential-provider-node/3.196.0:
     resolution: {integrity: sha512-PGY7pkmqgfEwTHsuUH6fGrXWri93jqKkMbhq/QJafMGtsVupfvXvE37Rl+qgjsZjRfROrEaeLw2DGrPPmVh2cg==}
@@ -1094,6 +1107,7 @@ packages:
       tslib: 2.4.0
     transitivePeerDependencies:
       - aws-crt
+    dev: false
 
   /@aws-sdk/credential-provider-process/3.193.0:
     resolution: {integrity: sha512-zpXxtQzQqkaUuFqmHW9dSkh9p/1k+XNKlwEkG8FTwAJNUWmy2ZMJv+8NTVn4s4vaRu7xJ1er9chspYr7mvxHlA==}
@@ -1103,6 +1117,7 @@ packages:
       '@aws-sdk/shared-ini-file-loader': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/credential-provider-sso/3.196.0:
     resolution: {integrity: sha512-hJV4LDVfvPfj5zC0ysHx3zkwwJOyF+BaMGaMzaScrHyijv5e3qZzdoBLbOQFmrqVnt7DjCU02NvRSS8amLpmSw==}
@@ -1115,6 +1130,7 @@ packages:
       tslib: 2.4.0
     transitivePeerDependencies:
       - aws-crt
+    dev: false
 
   /@aws-sdk/credential-provider-web-identity/3.193.0:
     resolution: {integrity: sha512-MIQY9KwLCBnRyIt7an4EtMrFQZz2HC1E8vQDdKVzmeQBBePhW61fnX9XDP9bfc3Ypg1NggLG00KBPEC88twLFg==}
@@ -1123,6 +1139,7 @@ packages:
       '@aws-sdk/property-provider': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/fetch-http-handler/3.193.0:
     resolution: {integrity: sha512-UhIS2LtCK9hqBzYVon6BI8WebJW1KC0GGIL/Gse5bqzU9iAGgFLAe66qg9k+/h3Jjc5LNAYzqXNVizMwn7689Q==}
@@ -1132,6 +1149,7 @@ packages:
       '@aws-sdk/types': 3.193.0
       '@aws-sdk/util-base64-browser': 3.188.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/hash-node/3.193.0:
     resolution: {integrity: sha512-O2SLPVBjrCUo+4ouAdRUoHBYsyurO9LcjNZNYD7YQOotBTbVFA3cx7kTZu+K4B6kX7FDaGbqbE1C/T1/eg/r+w==}
@@ -1140,18 +1158,21 @@ packages:
       '@aws-sdk/types': 3.193.0
       '@aws-sdk/util-buffer-from': 3.188.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/invalid-dependency/3.193.0:
     resolution: {integrity: sha512-54DCknekLwJAI1os76XJ8XCzfAH7BGkBGtlWk5WCNkZTfj3rf5RUiXz4uoKUMWE1rZmyMDoDDS1PBo+yTVKW5w==}
     dependencies:
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/is-array-buffer/3.188.0:
     resolution: {integrity: sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/middleware-content-length/3.193.0:
     resolution: {integrity: sha512-em0Sqo7O7DFOcVXU460pbcYuIjblDTZqK2YE62nQ0T+5Nbj+MSjuoite+rRRdRww9VqBkUROGKON45bUNjogtQ==}
@@ -1160,6 +1181,7 @@ packages:
       '@aws-sdk/protocol-http': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/middleware-endpoint/3.193.0:
     resolution: {integrity: sha512-Inbpt7jcHGvzF7UOJOCxx9wih0+eAQYERikokidWJa7M405EJpVYq1mGbeOcQUPANU3uWF1AObmUUFhbkriHQw==}
@@ -1173,6 +1195,7 @@ packages:
       '@aws-sdk/util-config-provider': 3.188.0
       '@aws-sdk/util-middleware': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/middleware-host-header/3.193.0:
     resolution: {integrity: sha512-aegzj5oRWd//lmfmkzRmgG2b4l3140v8Ey4QkqCxcowvAEX5a7rh23yuKaGtmiePwv2RQalCKz+tN6JXCm8g6Q==}
@@ -1181,6 +1204,7 @@ packages:
       '@aws-sdk/protocol-http': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/middleware-logger/3.193.0:
     resolution: {integrity: sha512-D/h1pU5tAcyJpJ8ZeD1Sta0S9QZPcxERYRBiJdEl8VUrYwfy3Cl1WJedVOmd5nG73ZLRSyHeXHewb/ohge3yKQ==}
@@ -1188,6 +1212,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/middleware-recursion-detection/3.193.0:
     resolution: {integrity: sha512-fMWP76Q1GOb/9OzS1arizm6Dbfo02DPZ6xp7OoAN3PS6ybH3Eb47s/gP3jzgBPAITQacFj4St/4a06YWYrN3NA==}
@@ -1196,6 +1221,7 @@ packages:
       '@aws-sdk/protocol-http': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/middleware-retry/3.193.0:
     resolution: {integrity: sha512-zTQkHLBQBJi6ns655WYcYLyLPc1tgbEYU080Oc8zlveLUqoDn1ogkcmNhG7XMeQuBvWZBYN7J3/wFaXlDzeCKg==}
@@ -1207,6 +1233,7 @@ packages:
       '@aws-sdk/util-middleware': 3.193.0
       tslib: 2.4.0
       uuid: 8.3.2
+    dev: false
 
   /@aws-sdk/middleware-sdk-sts/3.193.0:
     resolution: {integrity: sha512-TafiDkeflUsnbNa89TLkDnAiRRp1gAaZLDAjt75AzriRKZnhtFfYUXWb+qAuN50T+CkJ/gZI9LHDZL5ogz/HxQ==}
@@ -1218,6 +1245,7 @@ packages:
       '@aws-sdk/signature-v4': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/middleware-serde/3.193.0:
     resolution: {integrity: sha512-dH93EJYVztY+ZDPzSMRi9LfAZfKO+luH62raNy49hlNa4jiyE1Tc/+qwlmOEpfGsrtcZ9TgsON1uFF9sgBXXaA==}
@@ -1225,6 +1253,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/middleware-signing/3.193.0:
     resolution: {integrity: sha512-obBoELGPf5ikvHYZwbzllLeuODiokdDfe92Ve2ufeOa/d8+xsmbqNzNdCTLNNTmr1tEIaEE7ngZVTOiHqAVhyw==}
@@ -1236,12 +1265,14 @@ packages:
       '@aws-sdk/types': 3.193.0
       '@aws-sdk/util-middleware': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/middleware-stack/3.193.0:
     resolution: {integrity: sha512-Ix5d7gE6bZwFNIVf0dGnjYuymz1gjitNoAZDPpv1nEZlUMek/jcno5lmzWFzUZXY/azpbIyaPwq/wm/c69au5A==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/middleware-user-agent/3.193.0:
     resolution: {integrity: sha512-0vT6F9NwYQK7ARUUJeHTUIUPnupsO3IbmjHSi1+clkssFlJm2UfmSGeafiWe4AYH3anATTvZEtcxX5DZT/ExbA==}
@@ -1250,6 +1281,7 @@ packages:
       '@aws-sdk/protocol-http': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/node-config-provider/3.193.0:
     resolution: {integrity: sha512-5RLdjQLH69ISRG8TX9klSLOpEySXxj+z9E9Em39HRvw0/rDcd8poCTADvjYIOqRVvMka0z/hm+elvUTIVn/DRw==}
@@ -1259,6 +1291,7 @@ packages:
       '@aws-sdk/shared-ini-file-loader': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/node-http-handler/3.193.0:
     resolution: {integrity: sha512-DP4BmFw64HOShgpAPEEMZedVnRmKKjHOwMEoXcnNlAkMXnYUFHiKvudYq87Q2AnSlT6OHkyMviB61gEvIk73dA==}
@@ -1269,6 +1302,7 @@ packages:
       '@aws-sdk/querystring-builder': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/property-provider/3.193.0:
     resolution: {integrity: sha512-IaDR/PdZjKlAeSq2E/6u6nkPsZF9wvhHZckwH7uumq4ocWsWXFzaT+hKpV4YZPHx9n+K2YV4Gn/bDedpz99W1Q==}
@@ -1276,6 +1310,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/protocol-http/3.193.0:
     resolution: {integrity: sha512-r0wbTwFJyXq0uiImI6giqG3g/RO1N/y4wwPA7qr7OC+KXJ0NkyVxIf6e7Vx8h06aM1ATtngbwJaMP59kVCp85A==}
@@ -1283,6 +1318,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/querystring-builder/3.193.0:
     resolution: {integrity: sha512-PRaK6649iw0UO45UjUoiUzFcOKXZb8pMjjFJpqALpEvdZT3twxqhlPXujT7GWPKrSwO4uPLNnyYEtPY82wx2vw==}
@@ -1291,6 +1327,7 @@ packages:
       '@aws-sdk/types': 3.193.0
       '@aws-sdk/util-uri-escape': 3.188.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/querystring-parser/3.193.0:
     resolution: {integrity: sha512-dGEPCe8SK4/td5dSpiaEI3SvT5eHXrbJWbLGyD4FL3n7WCGMy2xVWAB/yrgzD0GdLDjDa8L5vLVz6yT1P9i+hA==}
@@ -1298,10 +1335,12 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/service-error-classification/3.193.0:
     resolution: {integrity: sha512-bPnXVu8ErE1RfWVVQKc2TE7EuoImUi4dSPW9g80fGRzJdQNwXb636C+7OUuWvSDzmFwuBYqZza8GZjVd+rz2zQ==}
     engines: {node: '>= 12.0.0'}
+    dev: false
 
   /@aws-sdk/shared-ini-file-loader/3.193.0:
     resolution: {integrity: sha512-hnvZup8RSpFXfah7Rrn6+lQJnAOCO+OiDJ2R/iMgZQh475GRQpLbu3cPhCOkjB14vVLygJtW8trK/0+zKq93bQ==}
@@ -1309,6 +1348,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/signature-v4-multi-region/3.193.0:
     resolution: {integrity: sha512-NUlTZVu7kB9LWk290ofWhDGK3O2qTx+RtAoCQbifn5mLe2d0FPIe9CibPg+IY4rkbXTyEBbSs2FaxFjcAlW8JA==}
@@ -1324,6 +1364,7 @@ packages:
       '@aws-sdk/types': 3.193.0
       '@aws-sdk/util-arn-parser': 3.188.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/signature-v4/3.193.0:
     resolution: {integrity: sha512-JEqqOB8wQZz6g1ERNUOIBFDFt8OJtz5G5Uh1CdkS5W66gyWnJEz/dE1hA2VTqqQwHGGEsIEV/hlzruU1lXsvFA==}
@@ -1335,6 +1376,7 @@ packages:
       '@aws-sdk/util-middleware': 3.193.0
       '@aws-sdk/util-uri-escape': 3.188.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/smithy-client/3.193.0:
     resolution: {integrity: sha512-BY0jhfW76vyXr7ODMaKO3eyS98RSrZgOMl6DTQV9sk7eFP/MPVlG7p7nfX/CDIgPBIO1z0A0i2CVIzYur9uGgQ==}
@@ -1343,10 +1385,12 @@ packages:
       '@aws-sdk/middleware-stack': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/types/3.193.0:
     resolution: {integrity: sha512-LV/wcPolRZKORrcHwkH59QMCkiDR5sM+9ZtuTxvyUGG2QFW/kjoxs08fUF10OWNJMrotBI+czDc5QJRgN8BlAw==}
     engines: {node: '>= 12.0.0'}
+    dev: false
 
   /@aws-sdk/url-parser/3.193.0:
     resolution: {integrity: sha512-hwD1koJlOu2a6GvaSbNbdo7I6a3tmrsNTZr8bCjAcbqpc5pDThcpnl/Uaz3zHmMPs92U8I6BvWoK6pH8By06qw==}
@@ -1354,17 +1398,20 @@ packages:
       '@aws-sdk/querystring-parser': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-arn-parser/3.188.0:
     resolution: {integrity: sha512-q4nZzt/g3sRY9a3sj1PaNFwql5bXfKSW4fRy0zLdbZHcYdgq2oQfVsJTIlL9lUNjifkXiIsmk61Q16JExtrLyw==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-base64-browser/3.188.0:
     resolution: {integrity: sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-base64-node/3.188.0:
     resolution: {integrity: sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==}
@@ -1372,17 +1419,20 @@ packages:
     dependencies:
       '@aws-sdk/util-buffer-from': 3.188.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-body-length-browser/3.188.0:
     resolution: {integrity: sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-body-length-node/3.188.0:
     resolution: {integrity: sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-buffer-from/3.188.0:
     resolution: {integrity: sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==}
@@ -1390,12 +1440,14 @@ packages:
     dependencies:
       '@aws-sdk/is-array-buffer': 3.188.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-config-provider/3.188.0:
     resolution: {integrity: sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-defaults-mode-browser/3.193.0:
     resolution: {integrity: sha512-9riQKFrSJcsNAMnPA/3ltpSxNykeO20klE/UKjxEoD7UWjxLwsPK22UJjFwMRaHoAFcZD0LU/SgPxbC0ktCYCg==}
@@ -1405,6 +1457,7 @@ packages:
       '@aws-sdk/types': 3.193.0
       bowser: 2.11.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-defaults-mode-node/3.193.0:
     resolution: {integrity: sha512-occQmckvPRiM4YQIZnulfKKKjykGKWloa5ByGC5gOEGlyeP9zJpfs4zc/M2kArTAt+d2r3wkBtsKe5yKSlVEhA==}
@@ -1416,6 +1469,7 @@ packages:
       '@aws-sdk/property-provider': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-endpoints/3.196.0:
     resolution: {integrity: sha512-X+DOpRUy/ij49a0GQtggk09oyIQGn0mhER6PbMT69IufZPIg3D5fC5FPEp8bfsPkb70fTEYQEsj/X/rgMQJKsA==}
@@ -1423,30 +1477,35 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-hex-encoding/3.188.0:
     resolution: {integrity: sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-locate-window/3.188.0:
     resolution: {integrity: sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-middleware/3.193.0:
     resolution: {integrity: sha512-+aC6pmkcGgpxaMWCH/FXTsGWl2W342oQGs1OYKGi+W8z9UguXrqamWjdkdMqgunvj9qOEG2KBMKz1FWFFZlUyA==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-uri-escape/3.188.0:
     resolution: {integrity: sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-user-agent-browser/3.193.0:
     resolution: {integrity: sha512-1EkGYsUtOMEyJG/UBIR4PtmO3lVjKNoUImoMpLtEucoGbWz5RG9zFSwLevjFyFs5roUBFlxkSpTMo8xQ3aRzQg==}
@@ -1454,6 +1513,7 @@ packages:
       '@aws-sdk/types': 3.193.0
       bowser: 2.11.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-user-agent-node/3.193.0:
     resolution: {integrity: sha512-G/2/1cSgsxVtREAm8Eq8Duib5PXzXknFRHuDpAxJ5++lsJMXoYMReS278KgV54cojOkAVfcODDTqmY3Av0WHhQ==}
@@ -1467,11 +1527,13 @@ packages:
       '@aws-sdk/node-config-provider': 3.193.0
       '@aws-sdk/types': 3.193.0
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-utf8-browser/3.188.0:
     resolution: {integrity: sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==}
     dependencies:
       tslib: 2.4.0
+    dev: false
 
   /@aws-sdk/util-utf8-node/3.188.0:
     resolution: {integrity: sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==}
@@ -1479,6 +1541,7 @@ packages:
     dependencies:
       '@aws-sdk/util-buffer-from': 3.188.0
       tslib: 2.4.0
+    dev: false
 
   /@babel/cli/7.19.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-643/TybmaCAe101m2tSVHi9UKpETXP9c/Ff4mD2tAwkdP6esKIfaauZFc67vGEM6r9fekbEGid+sZhbEnSe3dg==}
@@ -7941,6 +8004,7 @@ packages:
 
   /bowser/2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
+    dev: false
 
   /boxen/5.1.2:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
@@ -10939,6 +11003,7 @@ packages:
     hasBin: true
     dependencies:
       strnum: 1.0.5
+    dev: false
 
   /fastest-levenshtein/1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -17672,6 +17737,7 @@ packages:
 
   /strnum/1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+    dev: false
 
   /strong-log-transformer/2.1.0:
     resolution: {integrity: sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==}


### PR DESCRIPTION
Fix suggestion to issue #330.

`pnpm run deploy` fails on newly created projects due to a missing `@aws-sdk/client-eventbridge` dependency in `@swarmion/serverless-contracts`

This MR moves `@aws-sdk/client-eventbridge` from devDependencies to dependencies in `@swarmion/serverless-contracts`