### PR TITLE
chore: keep comments in .d.ts files

### DIFF
--- a/examples/swarmion-full-stack/tsconfig.json
+++ b/examples/swarmion-full-stack/tsconfig.json
@@ -4,7 +4,6 @@
     "esModuleInterop": true,
     "types": ["node", "vitest/globals"],
     "lib": ["es2020"],
-    "removeComments": true,
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/examples/swarmion-starter/tsconfig.json
+++ b/examples/swarmion-starter/tsconfig.json
@@ -4,7 +4,6 @@
     "esModuleInterop": true,
     "types": ["node", "vitest/globals"],
     "lib": ["es2020"],
-    "removeComments": true,
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "esModuleInterop": true,
     "types": ["node", "vitest/globals"],
     "lib": ["es2020"],
-    "removeComments": true,
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
We currently remove the comments from our .d.ts files.

This is a problem for our published libraries as they do not publish their nice JSDoc.

Also for the two starters, it seems to me that the benefits of removing comments is non-existent since we do not use `tsc` to transpile from TS to JS. On the contrary, keeping them would improve internal documentation.

Check out https://github.com/microsoft/TypeScript/issues/14619 for more context.

WDYT?