### PR TITLE
feat(serverless-contracts): add support for `aws_iam` authorizer for both `httpApi` and `restApi`

### DIFF
--- a/packages/serverless-contracts/src/contracts/apiGateway/types/constants.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/constants.ts
@@ -4,4 +4,9 @@
  */
 export type ApiGatewayIntegrationType = 'httpApi' | 'restApi';
 export type ApiGatewayKey = 'httpApi' | 'http';
-export type ApiGatewayAuthorizerType = 'cognito' | 'jwt' | 'lambda' | undefined;
+export type ApiGatewayAuthorizerType =
+  | 'cognito'
+  | 'jwt'
+  | 'lambda'
+  | 'aws_iam'
+  | undefined;


### PR DESCRIPTION
Improve Api Gateway authorizers

-  add support for `aws_iam` authorizer for both `httpApi` and `restApi`.