### PR TITLE
feat(serverless-helpers): export esbuild config and improve getCdkHandlerPath

### DIFF
--- a/packages/serverless-configuration/package.json
+++ b/packages/serverless-configuration/package.json
@@ -28,7 +28,8 @@
     "watch": "pnpm clean && concurrently 'pnpm:package-* --watch'"
   },
   "dependencies": {
-    "@babel/runtime": "^7.20.6"
+    "@babel/runtime": "^7.20.6",
+    "@swarmion/serverless-helpers": "workspace:^0.16.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/packages/serverless-configuration/src/sharedConfig.ts
+++ b/packages/serverless-configuration/src/sharedConfig.ts
@@ -1,3 +1,5 @@
+import { swarmionEsbuildConfig } from '@swarmion/serverless-helpers';
+
 export const projectName = 'swarmion';
 export const region = 'eu-west-1';
 export const frameworkVersion = '>=3.0.0';
@@ -30,15 +32,4 @@ export const sharedParams = {
   production: { profile: '' },
 };
 
-export const sharedEsbuildConfig = {
-  packager: 'pnpm',
-  bundle: true,
-  minify: true,
-  keepNames: true,
-  sourcemap: true,
-  exclude: ['aws-sdk'],
-  target: 'node16',
-  platform: 'node',
-  mainFields: ['module', 'main'],
-  concurrency: 5,
-};
+export const sharedEsbuildConfig = swarmionEsbuildConfig;

--- a/packages/serverless-configuration/tsconfig.json
+++ b/packages/serverless-configuration/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "baseUrl": "src"
   },
+  "references": [{ "path": "../serverless-helpers/tsconfig.build.json" }],
   "include": ["./**/*.ts"],
   "exclude": ["./dist"]
 }

--- a/packages/serverless-helpers/package.json
+++ b/packages/serverless-helpers/package.json
@@ -59,6 +59,7 @@
     "babel-plugin-module-resolver": "^4.1.0",
     "concurrently": "^7.6.0",
     "dependency-cruiser": "^12.1.0",
+    "esbuild": "^0.16.0",
     "eslint": "^8.29.0",
     "json-schema-to-ts": "^2.6.2",
     "prettier": "^2.8.1",

--- a/packages/serverless-helpers/src/configuration/esbuildConfig.ts
+++ b/packages/serverless-helpers/src/configuration/esbuildConfig.ts
@@ -1,0 +1,33 @@
+import type { BuildOptions } from 'esbuild';
+
+type EsbuildOptions = Omit<BuildOptions, 'watch'>;
+
+/**
+ * The interface for the Swarmion recommended configuration
+ *
+ * See https://github.com/floydspace/serverless-esbuild/blob/master/src/types.ts#L24
+ * And https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.BundlingOptions.html
+ */
+export interface SwarmionEsbuildConfig extends EsbuildOptions {
+  concurrency?: number;
+  packager: PackagerId;
+  exclude: '*' | string[];
+}
+
+type PackagerId = 'npm' | 'pnpm' | 'yarn';
+
+/**
+ * the recommended esbuild configuration for Swarmion
+ */
+export const swarmionEsbuildConfig: SwarmionEsbuildConfig = {
+  packager: 'pnpm',
+  bundle: true,
+  minify: true,
+  keepNames: true,
+  sourcemap: true,
+  exclude: ['aws-sdk'],
+  target: 'node16',
+  platform: 'node',
+  mainFields: ['module', 'main'],
+  concurrency: 5,
+};

--- a/packages/serverless-helpers/src/configuration/index.ts
+++ b/packages/serverless-helpers/src/configuration/index.ts
@@ -1,0 +1,1 @@
+export * from './esbuildConfig';

--- a/packages/serverless-helpers/src/helpers/__tests__/getCdkHandlerPath.test.ts
+++ b/packages/serverless-helpers/src/helpers/__tests__/getCdkHandlerPath.test.ts
@@ -1,0 +1,21 @@
+import { getCdkHandlerPath } from '../getCdkHandlerPath';
+
+describe('getCdkHandlerPath', () => {
+  it('should return the default path when given no option', () => {
+    expect(getCdkHandlerPath('/path/to/file')).toBe('/path/to/file/handler.ts');
+  });
+
+  it('should customize the extension when given an extension parameter', () => {
+    expect(getCdkHandlerPath('/path/to/file', { extension: 'mjs' })).toBe(
+      '/path/to/file/handler.mjs',
+    );
+  });
+
+  it('should customize the filename when given a filename parameter', () => {
+    expect(
+      getCdkHandlerPath('/path/to/file', {
+        fileName: 'toto',
+      }),
+    ).toBe('/path/to/file/toto.ts');
+  });
+});

--- a/packages/serverless-helpers/src/helpers/__tests__/getHandlerPath.test.ts
+++ b/packages/serverless-helpers/src/helpers/__tests__/getHandlerPath.test.ts
@@ -1,0 +1,15 @@
+import { getHandlerPath } from '../getHandlerPath';
+
+describe('getHandlerPath', () => {
+  it('should return the default path when given no option', () => {
+    expect(getHandlerPath('/path/to/file')).toBe('/path/to/file/handler.main');
+  });
+
+  it('should customize the filename when given a filename parameter', () => {
+    expect(
+      getHandlerPath('/path/to/file', {
+        fileName: 'toto',
+      }),
+    ).toBe('/path/to/file/toto.main');
+  });
+});

--- a/packages/serverless-helpers/src/helpers/getCdkHandlerPath.ts
+++ b/packages/serverless-helpers/src/helpers/getCdkHandlerPath.ts
@@ -1,6 +1,25 @@
-/** Helper to be used in CDK config.ts files to retrieve the path of the handler. */
-export const getCdkHandlerPath = (directoryPath: string): string => {
+type GetCdkHandlerPathProps = {
+  extension?: 'js' | 'ts' | 'cjs' | 'mjs';
+  fileName?: string;
+};
+
+/**
+ * Helper to be used in CDK config.ts files to retrieve the path of the handler.
+ *
+ * Use it with `__dirname` as the first argument to reference to neighboring files.
+ * You can also customize the filename and extension.
+ */
+export const getCdkHandlerPath = (
+  directoryPath: string,
+  props?: GetCdkHandlerPathProps,
+): string => {
   const processRunLocation = process.cwd();
 
-  return directoryPath.replace(processRunLocation + '/', '') + '/handler.ts';
+  const fileName = props?.fileName ?? 'handler';
+  const extension = props?.extension ?? 'ts';
+
+  return (
+    directoryPath.replace(processRunLocation + '/', '') +
+    `/${fileName}.${extension}`
+  );
 };

--- a/packages/serverless-helpers/src/helpers/getHandlerPath.ts
+++ b/packages/serverless-helpers/src/helpers/getHandlerPath.ts
@@ -1,6 +1,17 @@
+type GetHandlerPathProps = {
+  fileName?: string;
+};
+
 /** Helper to be used in config.ts files to retrieve the path of the handler. */
-export const getHandlerPath = (directoryPath: string): string => {
+export const getHandlerPath = (
+  directoryPath: string,
+  props?: GetHandlerPathProps,
+): string => {
   const processRunLocation = process.cwd();
 
-  return directoryPath.replace(processRunLocation + '/', '') + '/handler.main';
+  const fileName = props?.fileName ?? 'handler';
+
+  return (
+    directoryPath.replace(processRunLocation + '/', '') + `/${fileName}.main`
+  );
 };

--- a/packages/serverless-helpers/src/index.ts
+++ b/packages/serverless-helpers/src/index.ts
@@ -1,3 +1,4 @@
 export * from './helpers';
 export * from './types';
 export * from './mocks';
+export * from './configuration';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,6 +594,7 @@ importers:
       babel-plugin-module-resolver: ^4.1.0
       concurrently: ^7.6.0
       dependency-cruiser: ^12.1.0
+      esbuild: ^0.16.0
       eslint: ^8.29.0
       json-schema-to-ts: ^2.6.2
       prettier: ^2.8.1
@@ -622,6 +623,7 @@ importers:
       babel-plugin-module-resolver: 4.1.0
       concurrently: 7.6.0
       dependency-cruiser: 12.1.0
+      esbuild: 0.16.4
       eslint: 8.29.0
       json-schema-to-ts: 2.6.2
       prettier: 2.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,7 @@ importers:
       '@babel/preset-typescript': ^7.18.6
       '@babel/runtime': ^7.20.6
       '@serverless/typescript': ^3.25.0
+      '@swarmion/serverless-helpers': workspace:^0.16.1
       '@types/node': ^18.11.13
       babel-plugin-module-resolver: ^4.1.0
       concurrently: ^7.6.0
@@ -403,6 +404,7 @@ importers:
       vitest: ^0.25.7
     dependencies:
       '@babel/runtime': 7.20.6
+      '@swarmion/serverless-helpers': link:../serverless-helpers
     devDependencies:
       '@babel/cli': 7.19.3_@babel+core@7.20.5
       '@babel/core': 7.20.5


### PR DESCRIPTION
This PR adds two new features:
- export a default esbuild config from `serverless-helpers`. This can reduce the boilerplate on the Swarmion projects and can enable us to keep it up-to-date for everyone.
- improve the `getCdkHandlerPath` with optional arguments to override `fileName` and `extension`. This is useful in environments where you need to include js handlers directly in your CDK config.

@adriencaccia WDYT?