### PR TITLE
Add Amplify deployment to NextJs example [reopened]

### DIFF
--- a/examples/swarmion-with-next/frontend/next-app/.env.example
+++ b/examples/swarmion-with-next/frontend/next-app/.env.example
@@ -1,1 +1,5 @@
 NEXT_PUBLIC_API_URL=<your-api-url>
+
+GITHUB_OWNER=<github-user-name>
+GITHUB_REPO=<github-repository-name>
+GITHUB_OAUTH_TOKEN_SECRET_NAME=<ssm-key-to-github-token-with-repo-scope>

--- a/examples/swarmion-with-next/frontend/next-app/.gitignore
+++ b/examples/swarmion-with-next/frontend/next-app/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# CDK
+cdk.out

--- a/examples/swarmion-with-next/frontend/next-app/README.md
+++ b/examples/swarmion-with-next/frontend/next-app/README.md
@@ -1,0 +1,75 @@
+This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+
+## Getting Started
+
+First, run the development server:
+
+```bash
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+
+[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+
+The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+
+## Learn More
+
+To learn more about Next.js, take a look at the following resources:
+
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+
+You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+
+## Deploy on Amplify
+
+### Installation
+
+To deploy the NextJs application to an Amplify stack, in the frontend next app directory:
+
+1. Setup your repository configuration in [`sourceCodeProvider.ts`](./hosting/settings/sourceCodeProvider.ts)
+   > By default, a GitHub configuration is proposed. You need to create a GitHub token with `repo` scope and should store it safely in AWS Secrets Manager. Then, you need to update your `.env` (copy `.env.example`) with the GitHub owner, repository name and the key used in Secrets Manager to store the token.
+
+2. Deploy the Amplify stack by running
+
+   ```sh
+   pnpm bootstrap
+   pnpm run deploy
+   ```
+
+   _NB: `pnpm bootstrap` is required only once to bootstrap a CDK stack._
+
+3. Retrieve the app id from the shell output. Then, to enable NextJs, change the Amplify platform to "WEB_COMPUTE" by running
+
+   ```sh
+   aws amplify update-app --region <AWS region> --app-id <app id> --platform WEB_COMPUTE
+   ```
+
+### Uninstall
+
+To destroy the Amplify stack, run
+
+```sh
+pnpm run remove
+```
+
+### Continuous Deployment
+
+This project comes with a ready-to-use deployment configuration:
+
+- The project will be redeployed each time changes are detected on the `main` branch.
+  It is possible to change the default branch configuration in [`branchSettings.ts`](./hosting/settings/branchSettings.ts)
+- Whenever a branch starts with `feature/`, a preview will be built and deployed.
+  It is possible to update this branch preview configuration in [`branchSettings.ts`](./hosting/settings/branchSettings.ts)
+
+To include the app deployment in an advanced Continuous Deployment pipeline, you may use [webhooks](https://docs.aws.amazon.com/amplify/latest/userguide/webhooks.html). There is no CDK configuration available for now, but some commands are available in the [AWS CLI](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/amplify/create-webhook.html) to automate the process.
+
+## Deploy on Vercel
+
+Another way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new) from the creators of Next.js.
+
+Check out the [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.

--- a/examples/swarmion-with-next/frontend/next-app/README.md
+++ b/examples/swarmion-with-next/frontend/next-app/README.md
@@ -43,12 +43,6 @@ To deploy the NextJs application to an Amplify stack, in the frontend next app d
 
    _NB: `pnpm bootstrap` is required only once to bootstrap a CDK stack._
 
-3. Retrieve the app id from the shell output. Then, to enable NextJs, change the Amplify platform to "WEB_COMPUTE" by running
-
-   ```sh
-   aws amplify update-app --region <AWS region> --app-id <app id> --platform WEB_COMPUTE
-   ```
-
 ### Uninstall
 
 To destroy the Amplify stack, run

--- a/examples/swarmion-with-next/frontend/next-app/cdk.json
+++ b/examples/swarmion-with-next/frontend/next-app/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "pnpm ts-node --project ./tsconfig.cdk.json hosting/bin.ts"
+}

--- a/examples/swarmion-with-next/frontend/next-app/hosting/bin.ts
+++ b/examples/swarmion-with-next/frontend/next-app/hosting/bin.ts
@@ -1,0 +1,12 @@
+import * as cdk from 'aws-cdk-lib';
+
+import { AmplifyStack } from './stack';
+
+const app = new cdk.App();
+
+const CLOUDFORMATION_STACK_NAME = 'AmplifyStackSwarmion';
+
+new AmplifyStack(app, CLOUDFORMATION_STACK_NAME, {
+  analyticsReporting: true,
+  description: 'Swarmion NextJS App deployed with Amplify',
+});

--- a/examples/swarmion-with-next/frontend/next-app/hosting/settings/branchSettings.ts
+++ b/examples/swarmion-with-next/frontend/next-app/hosting/settings/branchSettings.ts
@@ -1,0 +1,15 @@
+import { AutoBranchCreation, BranchOptions } from '@aws-cdk/aws-amplify-alpha';
+
+export const MAIN_BRANCH = 'main';
+
+export const mainBranchSettings: BranchOptions = {
+  stage: 'PRODUCTION',
+  autoBuild: true,
+};
+
+export const branchPreviewConfiguration: AutoBranchCreation = {
+  // Define the pattern of branches that will be automatically built and deployed
+  patterns: ['feature/*'],
+  autoBuild: true,
+  pullRequestPreview: true,
+};

--- a/examples/swarmion-with-next/frontend/next-app/hosting/settings/buildSettings.ts
+++ b/examples/swarmion-with-next/frontend/next-app/hosting/settings/buildSettings.ts
@@ -1,0 +1,38 @@
+import { environmentVariables } from "./environmentVariables";
+
+export const buildSettings = {
+  version: '1.0',
+  applications: [
+    {
+      appRoot: 'frontend/next-app',
+      frontend: {
+        phases: {
+          preBuild: {
+            commands: [
+              'nvm install',
+              'nvm use',
+              // Avoid out of memory error. See https://cloudnamaste.com/amplify-console-build-fail-java-heap-out-of-memory/
+              'export NODE_OPTIONS=--max-old-space-size=8192',
+              'npm install -g pnpm',
+              // Ensure node_modules in the monorepo root folder are included in the artifacts
+              'pnpm install --virtual-store-dir frontend/next-app/node_modules/.pnpm',
+            ],
+          },
+          build: {
+            commands: [          
+            // Allow Next.js to access environment variables
+            // See https://docs.aws.amazon.com/amplify/latest/userguide/ssr-environment-variables.html
+            `env | grep -E '${Object.keys(environmentVariables).join('|')}' >> .env.production`,
+            // Build Next.js app
+            'pnpm build --no-lint',
+            ],
+          },
+        },
+        artifacts: {
+          baseDirectory: '.next',
+          files: ['**/*'],
+        },
+      },
+    },
+  ],
+};

--- a/examples/swarmion-with-next/frontend/next-app/hosting/settings/environmentVariables.ts
+++ b/examples/swarmion-with-next/frontend/next-app/hosting/settings/environmentVariables.ts
@@ -1,0 +1,5 @@
+export const environmentVariables = {
+  AMPLIFY_MONOREPO_APP_ROOT: 'frontend/next-app',
+  // https://docs.aws.amazon.com/amplify/latest/userguide/build-settings.html#enable-diff-deploy
+  AMPLIFY_DIFF_DEPLOY: 'false',
+};

--- a/examples/swarmion-with-next/frontend/next-app/hosting/settings/sourceCodeProvider.ts
+++ b/examples/swarmion-with-next/frontend/next-app/hosting/settings/sourceCodeProvider.ts
@@ -1,0 +1,19 @@
+import { GitHubSourceCodeProvider, GitHubSourceCodeProviderProps } from '@aws-cdk/aws-amplify-alpha';
+import { SecretValue } from 'aws-cdk-lib';
+import * as dotenv from 'dotenv';
+
+// Load environment variables from .env file
+dotenv.config();
+
+const githubConfiguration: GitHubSourceCodeProviderProps = {
+  owner: process.env.GITHUB_OWNER ?? 'undefined',
+  repository: process.env.GITHUB_REPO ?? 'undefined',
+  // Fill your secret in AWS Secrets Manager, as plain text, with the name defined in .env
+  oauthToken: SecretValue.secretsManager(
+    process.env.GITHUB_OAUTH_TOKEN_SECRET_NAME ?? 'undefined',
+  ),
+};
+
+export const sourceCodeProvider = new GitHubSourceCodeProvider(
+  githubConfiguration,
+);

--- a/examples/swarmion-with-next/frontend/next-app/hosting/stack.ts
+++ b/examples/swarmion-with-next/frontend/next-app/hosting/stack.ts
@@ -1,0 +1,49 @@
+import { App } from '@aws-cdk/aws-amplify-alpha';
+import { aws_iam, CfnOutput, Stack, StackProps } from 'aws-cdk-lib';
+import { BuildSpec } from 'aws-cdk-lib/aws-codebuild';
+import { Construct } from 'constructs';
+
+import {
+  branchPreviewConfiguration,
+  MAIN_BRANCH,
+  mainBranchSettings,
+} from './settings/branchSettings';
+import { buildSettings } from './settings/buildSettings';
+import { environmentVariables } from './settings/environmentVariables';
+import { sourceCodeProvider } from './settings/sourceCodeProvider';
+
+const AMPLIFY_APP_NAME = 'NextJS app from CDK';
+const AWS_AMPLIFY_RESOURCE_NAME = 'AmplifyAppWithSwarmion';
+
+export class AmplifyStack extends Stack {
+  constructor(scope: Construct, id: string, props: StackProps) {
+    super(scope, id, props);
+
+    // Amplify service role. Needed to detect NextJs framework. See this issue https://stackoverflow.com/a/69009971
+    const role = new aws_iam.Role(this, 'amplify-role-webapp', {
+      assumedBy: new aws_iam.ServicePrincipal('amplify.amazonaws.com'),
+      description: 'Custom role permitting resources creation from Amplify',
+    });
+
+    const iManagedPolicy = aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
+      'AdministratorAccess-Amplify',
+    );
+    role.addManagedPolicy(iManagedPolicy);
+
+    const amplifyApp = new App(this, AWS_AMPLIFY_RESOURCE_NAME, {
+      appName: AMPLIFY_APP_NAME,
+      description: 'Swarmion NextJS APP deployed with Amplify',
+      role,
+      sourceCodeProvider,
+      environmentVariables,
+      buildSpec: BuildSpec.fromObjectToYaml(buildSettings),
+      autoBranchCreation: branchPreviewConfiguration,
+      autoBranchDeletion: true,
+    });
+    amplifyApp.addBranch(MAIN_BRANCH, mainBranchSettings);
+
+    new CfnOutput(this, 'appId', {
+      value: amplifyApp.appId,
+    });
+  }
+}

--- a/examples/swarmion-with-next/frontend/next-app/package.json
+++ b/examples/swarmion-with-next/frontend/next-app/package.json
@@ -3,11 +3,18 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
+    "bootstrap": "cdk bootstrap",
+    "bootstrap-production": "cdk bootstrap --context stage=production",
+    "bootstrap-staging": "cdk bootstrap --context stage=staging",
     "build": "next build",
+    "deploy": "cdk deploy",
+    "deploy-production": "cdk deploy --context stage=production",
+    "deploy-staging": "cdk deploy --context stage=staging",
     "dev": "next dev",
     "lint-fix": "pnpm linter-base-config --fix",
     "lint-fix-all": "pnpm lint-fix .",
     "linter-base-config": "eslint --ext=js,ts,jsx,tsx .",
+    "remove": "cdk destroy",
     "start": "next start",
     "stylelint-base-config": "stylelint",
     "stylelint-fix": "pnpm stylelint-base-config --fix",
@@ -30,6 +37,7 @@
     "react-intl": "^6.2.5"
   },
   "devDependencies": {
+    "@aws-cdk/aws-amplify-alpha": "2.52.0-alpha.0",
     "@stylelint/postcss-css-in-js": "^0.38.0",
     "@testing-library/dom": "^8.19.1",
     "@testing-library/jest-dom": "^5.16.4",
@@ -39,7 +47,11 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "@types/testing-library__jest-dom": "^5.14.5",
+    "aws-cdk": "^2.52.0",
+    "aws-cdk-lib": "^2.52.0",
+    "constructs": "^10.0.36",
     "dependency-cruiser": "^12.3.0",
+    "dotenv": "^16.0.3",
     "eslint": "^8.31.0",
     "eslint-config-next": "^13.1.1",
     "eslint-plugin-jsx-a11y": "^6.5.1",
@@ -57,6 +69,7 @@
     "stylelint-config-standard": "^29.0.0",
     "stylelint-order": "^6.0.0",
     "ts-jest": "^29.0.3",
+    "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
   }
 }

--- a/examples/swarmion-with-next/frontend/next-app/tsconfig.cdk.json
+++ b/examples/swarmion-with-next/frontend/next-app/tsconfig.cdk.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "types": ["node"]
+  },
+  "exclude": ["./**/*.test.ts", "./**/*.test.tsx", "node_modules"]
+}

--- a/examples/swarmion-with-next/nx.json
+++ b/examples/swarmion-with-next/nx.json
@@ -5,6 +5,7 @@
       "runner": "nx/tasks-runners/default",
       "options": {
         "cacheableOperations": [
+          "bootstrap",
           "build",
           "package",
           "test",
@@ -34,7 +35,7 @@
     },
     "deploy": {
       "inputs": ["production", "^production"],
-      "dependsOn": ["^package", "^deploy", "^build"]
+      "dependsOn": ["^package", "^deploy", "^build", "bootstrap"]
     },
     "test": {
       "inputs": ["default", "^production", "{workspaceRoot}/.eslintrc.js"],

--- a/examples/swarmion-with-next/pnpm-lock.yaml
+++ b/examples/swarmion-with-next/pnpm-lock.yaml
@@ -116,6 +116,7 @@ importers:
 
   frontend/next-app:
     specifiers:
+      '@aws-cdk/aws-amplify-alpha': 2.52.0-alpha.0
       '@emotion/styled': ^11.10.5
       '@mui/lab': 5.0.0-alpha.114
       '@mui/material': ^5.11.3
@@ -130,8 +131,12 @@ importers:
       '@types/react': ^18.0.26
       '@types/react-dom': ^18.0.10
       '@types/testing-library__jest-dom': ^5.14.5
+      aws-cdk: ^2.52.0
+      aws-cdk-lib: ^2.52.0
       axios: ^1.2.2
+      constructs: ^10.0.36
       dependency-cruiser: ^12.3.0
+      dotenv: ^16.0.3
       eslint: ^8.31.0
       eslint-config-next: ^13.1.1
       eslint-plugin-jsx-a11y: ^6.5.1
@@ -153,6 +158,7 @@ importers:
       stylelint-config-standard: ^29.0.0
       stylelint-order: ^6.0.0
       ts-jest: ^29.0.3
+      ts-node: ^10.9.1
       typescript: ^4.9.4
     dependencies:
       '@emotion/styled': 11.10.5_jp5djshq6aqfasno3mth3hguci
@@ -166,6 +172,7 @@ importers:
       react-dom: 18.2.0_react@18.2.0
       react-intl: 6.2.5_o77wnou4wwnegu5woljtklrzru
     devDependencies:
+      '@aws-cdk/aws-amplify-alpha': 2.52.0-alpha.0_pkxi4sd626zcnsc5s4mo3wcqga
       '@stylelint/postcss-css-in-js': 0.38.0_britvnvafsaqvp7ihzdwtiasju
       '@testing-library/dom': 8.19.1
       '@testing-library/jest-dom': 5.16.5
@@ -175,7 +182,11 @@ importers:
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.10
       '@types/testing-library__jest-dom': 5.14.5
+      aws-cdk: 2.53.0
+      aws-cdk-lib: 2.53.0_constructs@10.1.177
+      constructs: 10.1.177
       dependency-cruiser: 12.3.0
+      dotenv: 16.0.3
       eslint: 8.31.0
       eslint-config-next: 13.1.1_iukboom6ndih5an6iafl45j2fe
       eslint-plugin-jsx-a11y: 6.6.1_eslint@8.31.0
@@ -183,7 +194,7 @@ importers:
       eslint-plugin-react-hooks: 4.6.0_eslint@8.31.0
       eslint-plugin-risxss: 2.1.0
       eslint-plugin-testing-library: 5.9.1_iukboom6ndih5an6iafl45j2fe
-      jest: 29.3.1_@types+node@18.11.18
+      jest: 29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4
       jest-environment-jsdom: 29.3.1
       postcss: 8.4.20
       postcss-syntax: 0.36.2_postcss@8.4.20
@@ -193,6 +204,7 @@ importers:
       stylelint-config-standard: 29.0.0_stylelint@14.16.1
       stylelint-order: 6.0.1_stylelint@14.16.1
       ts-jest: 29.0.3_b6ud3wjfzxmze5tmlpgpdpo43e
+      ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
       typescript: 4.9.4
 
   packages/serverless-configuration:
@@ -242,6 +254,29 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.17
+
+  /@aws-cdk/asset-awscli-v1/2.2.25:
+    resolution: {integrity: sha512-uC7XB5xCpFni3nlKxhkkvWpmp+xaGcBgtRBDq2/SDQ5brF5xQaLB+JVx0S/HvxztWpNLkn9A0svnyTyUFfCOpA==}
+    dev: true
+
+  /@aws-cdk/asset-kubectl-v20/2.1.1:
+    resolution: {integrity: sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==}
+    dev: true
+
+  /@aws-cdk/asset-node-proxy-agent-v5/2.0.31:
+    resolution: {integrity: sha512-kjNxq9oTR/e8M2K2aMKnuK0rXW6gUd+HAEzSiJNGivqi8ZHJLRvyVdYR7uhocxKxsI8eS71oZDxVVWMgO+iMKg==}
+    dev: true
+
+  /@aws-cdk/aws-amplify-alpha/2.52.0-alpha.0_pkxi4sd626zcnsc5s4mo3wcqga:
+    resolution: {integrity: sha512-n8uIbFkj9zCUwM/2Lv2iA0Ofcy+2No3d9f7jG5xYYmf7iEm9t9MCV6B0Dsvn8UanV0osJVW4CPboZe0fa5hArQ==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      aws-cdk-lib: ^2.52.0
+      constructs: ^10.0.0
+    dependencies:
+      aws-cdk-lib: 2.53.0_constructs@10.1.177
+      constructs: 10.1.177
+    dev: true
 
   /@aws-crypto/ie11-detection/2.0.2:
     resolution: {integrity: sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==}
@@ -1185,9 +1220,10 @@ packages:
     resolution: {integrity: sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.4
-      '@babel/types': 7.19.4
+      '@babel/helper-function-name': 7.19.0
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.12
+      '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1372,7 +1408,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
-    dev: false
 
   /@babel/template/7.18.10:
     resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
@@ -1442,6 +1477,10 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+
+  /@balena/dockerignore/1.0.2:
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+    dev: true
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2184,7 +2223,7 @@ packages:
       debug: 4.3.4
       espree: 9.4.0
       globals: 13.19.0
-      ignore: 5.2.0
+      ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -2309,7 +2348,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core/29.3.1:
+  /@jest/core/29.3.1_ts-node@10.9.1:
     resolution: {integrity: sha512-0ohVjjRex985w5MmO5L3u5GR1O30DexhBSpuwx2P+9ftyqHdJXnk7IUWiP80oHMvt7ubHCJHxV0a0vlKVuZirw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -2330,7 +2369,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.2.0
-      jest-config: 29.3.1_@types+node@18.11.18
+      jest-config: 29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4
       jest-haste-map: 29.3.1
       jest-message-util: 29.3.1
       jest-regex-util: 29.2.0
@@ -3708,7 +3747,7 @@ packages:
       eslint: 8.31.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.31.0
-      semver: 7.3.7
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3809,12 +3848,6 @@ packages:
   /acorn-walk/8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
-    dev: true
-
-  /acorn/8.8.0:
-    resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
     dev: true
 
   /acorn/8.8.1:
@@ -4042,7 +4075,7 @@ packages:
     resolution: {integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==}
     engines: {node: '>=6.0'}
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.7
       '@babel/runtime-corejs3': 7.20.1
     dev: true
 
@@ -4099,7 +4132,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.4
+      es-abstract: 1.21.0
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -4160,6 +4193,45 @@ packages:
   /available-typed-arrays/1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /aws-cdk-lib/2.53.0_constructs@10.1.177:
+    resolution: {integrity: sha512-ADpJ9luJxzmOrP/GJ37nA1YtdNmsOsjE+NZnQOpB7YL0spUxZJGNVAselaFLSDZmIsC6d9mSnW81fj4SDP1gAw==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      constructs: ^10.0.0
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.25
+      '@aws-cdk/asset-kubectl-v20': 2.1.1
+      '@aws-cdk/asset-node-proxy-agent-v5': 2.0.31
+      '@balena/dockerignore': 1.0.2
+      case: 1.6.3
+      constructs: 10.1.177
+      fs-extra: 9.1.0
+      ignore: 5.2.0
+      jsonschema: 1.4.1
+      minimatch: 3.1.2
+      punycode: 2.1.1
+      semver: 7.3.8
+      yaml: 1.10.2
+    dev: true
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - yaml
+
+  /aws-cdk/2.53.0:
+    resolution: {integrity: sha512-Tt/H7quNxA/Z0COwHnznnW7+6iJ1oUuJ/dZ5kjPTBtbgMvxRXKzZLDTanlTaET4Q7l6PprQPbUkWkYpka6v0qw==}
+    engines: {node: '>= 14.15.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /aws-sdk/2.1289.0:
@@ -4521,6 +4593,11 @@ packages:
   /caniuse-lite/1.0.30001442:
     resolution: {integrity: sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==}
 
+  /case/1.6.3:
+    resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
+    engines: {node: '>= 0.8.0'}
+    dev: true
+
   /chai/4.3.7:
     resolution: {integrity: sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==}
     engines: {node: '>=4'}
@@ -4836,6 +4913,11 @@ packages:
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.5.1
+    dev: true
+
+  /constructs/10.1.177:
+    resolution: {integrity: sha512-EaQLoc5ycemJM9RfpGXcgiGRZkXkf+BBzDhp6WNmM18KfrIusz2ZCisJUu7tpCusWyS7OXMADk+vVQ+HIYEo1g==}
+    engines: {node: '>= 14.17.0'}
     dev: true
 
   /content-disposition/0.5.4:
@@ -5479,36 +5561,6 @@ packages:
     dependencies:
       is-arrayish: 0.2.1
 
-  /es-abstract/1.20.4:
-    resolution: {integrity: sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      es-to-primitive: 1.2.1
-      function-bind: 1.1.1
-      function.prototype.name: 1.1.5
-      get-intrinsic: 1.1.3
-      get-symbol-description: 1.0.0
-      has: 1.0.3
-      has-property-descriptors: 1.0.0
-      has-symbols: 1.0.3
-      internal-slot: 1.0.4
-      is-callable: 1.2.7
-      is-negative-zero: 2.0.2
-      is-regex: 1.1.4
-      is-shared-array-buffer: 1.0.2
-      is-string: 1.0.7
-      is-weakref: 1.0.2
-      object-inspect: 1.12.2
-      object-keys: 1.1.1
-      object.assign: 4.1.4
-      regexp.prototype.flags: 1.4.3
-      safe-regex-test: 1.0.0
-      string.prototype.trimend: 1.0.6
-      string.prototype.trimstart: 1.0.6
-      unbox-primitive: 1.0.2
-    dev: true
-
   /es-abstract/1.21.0:
     resolution: {integrity: sha512-GUGtW7eXQay0c+PRq0sGIKSdaBorfVqsCMhGHo4elP7YVqZu9nCZS4UkK4gv71gOWNMra/PaSKD3ao1oWExO0g==}
     engines: {node: '>= 0.4'}
@@ -6088,9 +6140,9 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.7
       aria-query: 4.2.2
-      array-includes: 3.1.5
+      array-includes: 3.1.6
       ast-types-flow: 0.0.7
       axe-core: 4.5.1
       axobject-query: 2.2.0
@@ -6833,7 +6885,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -6889,7 +6941,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 5.1.0
+      minimatch: 5.1.2
       once: 1.4.0
     dev: true
 
@@ -7696,7 +7748,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/29.3.1_@types+node@18.11.18:
+  /jest-cli/29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4:
     resolution: {integrity: sha512-TO/ewvwyvPOiBBuWZ0gm04z3WWP8TIK8acgPzE4IxgsLKQgb377NYGrQLc3Wl/7ndWzIH2CDNNsUjGxwLL43VQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -7706,14 +7758,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.3.1
+      '@jest/core': 29.3.1_ts-node@10.9.1
       '@jest/test-result': 29.3.1
       '@jest/types': 29.3.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.3.1_@types+node@18.11.18
+      jest-config: 29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4
       jest-util: 29.3.1
       jest-validate: 29.3.1
       prompts: 2.4.2
@@ -7724,7 +7776,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config/29.3.1_@types+node@18.11.18:
+  /jest-config/29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4:
     resolution: {integrity: sha512-y0tFHdj2WnTEhxmGUK1T7fgLen7YK4RtfvpLFBXfQkh2eMJAQq24Vx9472lvn5wg0MAO6B+iPfJfzdR9hJYalg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -7759,6 +7811,7 @@ packages:
       pretty-format: 29.3.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
+      ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8073,7 +8126,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest/29.3.1_@types+node@18.11.18:
+  /jest/29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4:
     resolution: {integrity: sha512-6iWfL5DTT0Np6UYs/y5Niu7WIfNv/wRTtN5RSXt2DIEft3dx3zPuw/3WJQBCJfmEzvDiEKwoqMbGD9n49+qLSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -8083,10 +8136,10 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.3.1
+      '@jest/core': 29.3.1_ts-node@10.9.1
       '@jest/types': 29.3.1
       import-local: 3.1.0
-      jest-cli: 29.3.1_@types+node@18.11.18
+      jest-cli: 29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -8264,6 +8317,10 @@ packages:
   /jsonparse/1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
+    dev: true
+
+  /jsonschema/1.4.1:
+    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
     dev: true
 
   /jsx-ast-utils/3.3.3:
@@ -9175,7 +9232,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.4
+      es-abstract: 1.21.0
     dev: true
 
   /object.fromentries/2.0.6:
@@ -9184,14 +9241,14 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.4
+      es-abstract: 1.21.0
     dev: true
 
   /object.hasown/1.1.2:
     resolution: {integrity: sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==}
     dependencies:
       define-properties: 1.1.4
-      es-abstract: 1.20.4
+      es-abstract: 1.21.0
     dev: true
 
   /object.values/1.1.5:
@@ -9209,7 +9266,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.4
+      es-abstract: 1.21.0
     dev: true
 
   /once/1.4.0:
@@ -11165,7 +11222,7 @@ packages:
       '@babel/core': 7.20.12
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.3.1_@types+node@18.11.18
+      jest: 29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4
       jest-util: 29.3.1
       json5: 2.2.1
       lodash.memoize: 4.1.2
@@ -11195,7 +11252,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.11.18
-      acorn: 8.8.0
+      acorn: 8.8.1
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1


### PR DESCRIPTION
Reopen PR #363

Starting from `feat/swarmion-with-next` branch, I added an option to deploy the NextJs 13 app to Amplify, with a CDK construct.
See the updated README for more details on setup and use.

Thanks to @alexandrepernin who first deployed a POC of this new deployment option!

![image](https://user-images.githubusercontent.com/46320048/205347401-b7207ee3-d157-4390-9c14-0b8684582756.png)
