### PR TITLE
chore: remove explicit pnpm version from CI

### DIFF
--- a/.github/actions/install-node-deps/action.yml
+++ b/.github/actions/install-node-deps/action.yml
@@ -4,8 +4,6 @@ runs:
   using: 'composite'
   steps:
     - uses: pnpm/action-setup@v2.2.4
-      with:
-        version: 7.23.0
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v3
       with:

--- a/examples/swarmion-full-stack/.github/workflows/merge-main.yml
+++ b/examples/swarmion-full-stack/.github/workflows/merge-main.yml
@@ -26,8 +26,6 @@ jobs:
           fetch-depth: 0
       - uses: nrwl/nx-set-shas@v3
       - uses: pnpm/action-setup@v2.2.3
-        with:
-          version: 7.23.0
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:

--- a/examples/swarmion-full-stack/.github/workflows/pr.yml
+++ b/examples/swarmion-full-stack/.github/workflows/pr.yml
@@ -26,8 +26,6 @@ jobs:
           fetch-depth: 0
       - uses: nrwl/nx-set-shas@v3
       - uses: pnpm/action-setup@v2.2.3
-        with:
-          version: 7.23.0
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:

--- a/examples/swarmion-starter/.github/workflows/merge-main.yml
+++ b/examples/swarmion-starter/.github/workflows/merge-main.yml
@@ -26,8 +26,6 @@ jobs:
           fetch-depth: 0
       - uses: nrwl/nx-set-shas@v3
       - uses: pnpm/action-setup@v2.2.3
-        with:
-          version: 7.23.0
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:

--- a/examples/swarmion-starter/.github/workflows/pr.yml
+++ b/examples/swarmion-starter/.github/workflows/pr.yml
@@ -26,8 +26,6 @@ jobs:
           fetch-depth: 0
       - uses: nrwl/nx-set-shas@v3
       - uses: pnpm/action-setup@v2.2.3
-        with:
-          version: 7.23.0
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:

--- a/examples/swarmion-with-next/.github/workflows/merge-main.yml
+++ b/examples/swarmion-with-next/.github/workflows/merge-main.yml
@@ -26,8 +26,6 @@ jobs:
           fetch-depth: 0
       - uses: nrwl/nx-set-shas@v3
       - uses: pnpm/action-setup@v2.2.3
-        with:
-          version: 7.23.0
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:

--- a/examples/swarmion-with-next/.github/workflows/pr.yml
+++ b/examples/swarmion-with-next/.github/workflows/pr.yml
@@ -26,8 +26,6 @@ jobs:
           fetch-depth: 0
       - uses: nrwl/nx-set-shas@v3
       - uses: pnpm/action-setup@v2.2.3
-        with:
-          version: 7.23.0
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
"version" is optional and by default, gets the version from package.json See https://github.com/pnpm/action-setup\#version