### PR TITLE
feat(serverless-helpers): export serverless provider type

### DIFF
--- a/backend/orchestrator/serverless.ts
+++ b/backend/orchestrator/serverless.ts
@@ -15,8 +15,8 @@ import {
 } from '@swarmion/serverless-configuration';
 import { ServerlessContracts } from '@swarmion/serverless-plugin';
 
-import { functions } from 'functions';
-import { OrchestratorStack } from 'resources';
+import { functions } from './functions';
+import { OrchestratorStack } from './resources';
 
 const serverlessConfiguration: AWS &
   ServerlessContracts &
@@ -33,9 +33,7 @@ const serverlessConfiguration: AWS &
     'serverless-analyze-bundle-plugin',
   ],
   params: sharedParams,
-  provider: {
-    ...sharedProviderConfig,
-  },
+  provider: sharedProviderConfig,
   functions,
   package: { individually: true },
   custom: {

--- a/packages/serverless-configuration/src/sharedConfig.ts
+++ b/packages/serverless-configuration/src/sharedConfig.ts
@@ -1,4 +1,7 @@
-import { swarmionEsbuildConfig } from '@swarmion/serverless-helpers';
+import {
+  ServerlessProviderConfig,
+  swarmionEsbuildConfig,
+} from '@swarmion/serverless-helpers';
 
 export const projectName = 'swarmion';
 export const region = 'eu-west-1';
@@ -6,7 +9,7 @@ export const frameworkVersion = '>=3.0.0';
 
 export const defaultEnvironment = 'dev';
 
-export const sharedProviderConfig = {
+export const sharedProviderConfig: ServerlessProviderConfig = {
   name: 'aws',
   runtime: 'nodejs16.x',
   architecture: 'arm64',
@@ -18,7 +21,18 @@ export const sharedProviderConfig = {
     NODE_OPTIONS: '--enable-source-maps --stack-trace-limit=1000',
   },
   deploymentMethod: 'direct',
-} as const;
+  httpApi: {
+    payload: '2.0',
+    cors: {
+      // @ts-expect-error we use a configuration per environment so we put it as a serverless variable
+      allowedOrigins: '${param:apiGatewayCorsAllowedOrigins}',
+      allowedHeaders: ['Content-Type', 'Authorization', 'Origin'],
+      allowedMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+      allowCredentials: true,
+    },
+    metrics: true,
+  },
+};
 
 /**
  * common profiles settings. This must be put in the `custom` section of the `serverless.ts`
@@ -27,9 +41,12 @@ export const sharedProviderConfig = {
  * An empty string for a profile means that the default profile will be used
  */
 export const sharedParams = {
-  dev: { profile: 'swarmion-developer' },
-  staging: { profile: '' },
-  production: { profile: '' },
+  dev: {
+    profile: 'swarmion-developer',
+    apiGatewayCorsAllowedOrigins: ['localhost:3000'],
+  },
+  staging: { profile: '', apiGatewayCorsAllowedOrigins: [] },
+  production: { profile: '', apiGatewayCorsAllowedOrigins: [] },
 };
 
 export const sharedEsbuildConfig = swarmionEsbuildConfig;

--- a/packages/serverless-helpers/src/types/serverless.ts
+++ b/packages/serverless-helpers/src/types/serverless.ts
@@ -5,5 +5,13 @@ type FunctionsIamRoleStatements = {
   iamRoleStatementsInherit?: boolean;
 };
 
+/**
+ * The Lambda configuration type for Serverless Framework
+ */
 export type LambdaFunction = Exclude<AWS['functions'], undefined>[string] &
   FunctionsIamRoleStatements;
+
+/**
+ * The provider Serverless configuration
+ */
+export type ServerlessProviderConfig = AWS['provider'];


### PR DESCRIPTION
This is a first PR in order to tackle #445 

Export a type for the serverless provider config.

Next step is using it in the examples