### PR TITLE
ci: make sure deploy is working when validate-tests is skipped

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -104,6 +104,7 @@ jobs:
   deploy:
     name: Deploy production
     needs: validate-tests
+    if: ${{ always() && needs.validate-tests.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Related issue: https://github.com/actions/runner/issues/2205
