### PR TITLE
feat(serverless-contracts): Add type helper to extract event type from contract

### DIFF
--- a/packages/serverless-contracts/src/contracts/apiGateway/__tests__/lambdaHandler.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__tests__/lambdaHandler.test.ts
@@ -23,7 +23,7 @@ import {
 } from '../__mocks__/httpApiGatewayContract';
 import { ApiGatewayContract } from '../apiGatewayContract';
 import { getLambdaHandler } from '../features';
-import { SwarmionApiGatewayHandler } from '../types';
+import { SwarmionApiGatewayEvent, SwarmionApiGatewayHandler } from '../types';
 
 describe('apiGateway lambda handler', () => {
   describe('httpApi, with authorizer, when all parameters are set', () => {
@@ -189,19 +189,18 @@ describe('apiGateway lambda handler', () => {
       };
       expect(getLambdaHandler(httpApiContract)(handler)).toEqual(handler);
 
-      const { id, name } = await handler(
-        {
-          pathParameters: { userId: 'toto', pageNumber: '15' },
-          body: { foo: 'bar' },
-          headers: {
-            myHeader: 'MyCustomHeader',
-            anotherHeader: 'anotherHeader',
-          },
-          queryStringParameters: { testId: 'myTestId' },
-          requestContext: fakeRequestContext,
+      const event: SwarmionApiGatewayEvent<typeof httpApiContract> = {
+        pathParameters: { userId: 'toto', pageNumber: '15' },
+        body: { foo: 'bar' },
+        headers: {
+          myHeader: 'MyCustomHeader',
+          anotherHeader: 'anotherHeader',
         },
-        fakeContext,
-      );
+        queryStringParameters: { testId: 'myTestId' },
+        requestContext: fakeRequestContext,
+      };
+
+      const { id, name } = await handler(event, fakeContext);
 
       expect(id).toBe('hello');
       expect(name).toBe('bar15myTestIdMyCustomHeaderclaimBar');

--- a/packages/serverless-contracts/src/contracts/apiGateway/__tests__/lambdaHandler.type.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__tests__/lambdaHandler.type.test.ts
@@ -20,6 +20,7 @@ import {
   HeadersType,
   PathParametersType,
   QueryStringParametersType,
+  SwarmionApiGatewayEvent,
 } from '../types';
 
 export const httpApiGatewayContract = new ApiGatewayContract({
@@ -47,6 +48,7 @@ type MyEventType = HandlerEventType<
   CustomRequestContextType<ContractType>,
   BodyType<ContractType>
 >;
+type MyHelperEventType = SwarmionApiGatewayEvent<typeof httpApiGatewayContract>;
 type ExpectedEventType = {
   requestContext: APIGatewayEventRequestContextV2WithAuthorizer<APIGatewayEventRequestContextJWTAuthorizer> & {
     [x: string]: unknown;
@@ -80,6 +82,11 @@ type Check = A.Equals<MyEventType, ExpectedEventType>;
 
 const check: Check = 1;
 check;
+
+type CheckHelper = A.Equals<MyHelperEventType, ExpectedEventType>;
+
+const checkHelper: CheckHelper = 1;
+checkHelper;
 
 // test with some keys missing
 type IncompleteEventType = HandlerEventType<

--- a/packages/serverless-contracts/src/contracts/apiGateway/types/apiGateway.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/apiGateway.ts
@@ -1,0 +1,68 @@
+import {
+  APIGatewayEventRequestContextV2WithAuthorizer,
+  APIGatewayProxyCallback,
+  APIGatewayProxyCallbackV2,
+  APIGatewayProxyEventBase,
+  APIGatewayProxyEventV2WithRequestContext,
+  APIGatewayProxyResult,
+  APIGatewayProxyResultV2,
+  Context,
+} from 'aws-lambda';
+
+import { AuthorizerContext } from './authorizerContext';
+import {
+  ApiGatewayAuthorizerType,
+  ApiGatewayIntegrationType,
+} from './constants';
+
+type HandlerCallback<IntegrationType> = IntegrationType extends 'restApi'
+  ? APIGatewayProxyCallback
+  : APIGatewayProxyCallbackV2;
+
+/**
+ * The type of an ApiGateway event. This is the actual event that will
+ * be passed to the lambda, not the Swarmion inferred one.
+ *
+ * See https://docs.aws.amazon.com/lambda/latest/dg/typescript-handler.html.
+ */
+export type ApiGatewayEvent<
+  IntegrationType extends ApiGatewayIntegrationType,
+  AuthorizerType extends ApiGatewayAuthorizerType,
+> = IntegrationType extends 'restApi'
+  ? APIGatewayProxyEventBase<AuthorizerContext<AuthorizerType>>
+  : APIGatewayProxyEventV2WithRequestContext<
+      APIGatewayEventRequestContextV2WithAuthorizer<
+        AuthorizerContext<AuthorizerType>
+      >
+    >;
+
+/**
+ * The type of an ApiGateway event. This is the actual event that will
+ * be passed to the lambda, not the Swarmion inferred one.
+ *
+ * See https://docs.aws.amazon.com/lambda/latest/dg/typescript-handler.html.
+ */
+export type ApiGatewayResult<
+  IntegrationType extends ApiGatewayIntegrationType,
+  Output,
+> = IntegrationType extends 'restApi'
+  ? APIGatewayProxyResult
+  : APIGatewayProxyResultV2<Output>;
+
+/**
+ * The type of an ApiGateway handler. This is the actual version that will
+ * be executed by the lambda, not the Swarmion inferred one.
+ *
+ * See https://docs.aws.amazon.com/lambda/latest/dg/typescript-handler.html.
+ */
+export type ApiGatewayHandler<
+  IntegrationType extends ApiGatewayIntegrationType,
+  AuthorizerType extends ApiGatewayAuthorizerType,
+  Output,
+  AdditionalArgs extends unknown[] = never[],
+> = (
+  event: ApiGatewayEvent<IntegrationType, AuthorizerType>,
+  context: Context,
+  callback: HandlerCallback<IntegrationType>,
+  ...additionalArgs: AdditionalArgs
+) => Promise<ApiGatewayResult<IntegrationType, Output>>;

--- a/packages/serverless-contracts/src/contracts/apiGateway/types/authorizerContext.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/authorizerContext.ts
@@ -1,0 +1,17 @@
+import {
+  APIGatewayEventRequestContextJWTAuthorizer,
+  APIGatewayEventRequestContextLambdaAuthorizer,
+  APIGatewayProxyCognitoAuthorizer,
+} from 'aws-lambda';
+
+import { ApiGatewayAuthorizerType } from './constants';
+
+export type AuthorizerContext<AuthorizerType extends ApiGatewayAuthorizerType> =
+  AuthorizerType extends 'cognito'
+    ? APIGatewayProxyCognitoAuthorizer
+    : AuthorizerType extends 'jwt'
+    ? APIGatewayEventRequestContextJWTAuthorizer
+    : AuthorizerType extends 'lambda'
+    ? // We use unknown for now because we would need another schema to define the authorizer context
+      APIGatewayEventRequestContextLambdaAuthorizer<unknown>
+    : undefined;

--- a/packages/serverless-contracts/src/contracts/apiGateway/types/index.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/index.ts
@@ -3,3 +3,4 @@ export * from './requestParameters';
 export * from './fullContract';
 export * from './lambdaHandler';
 export * from './lambdaTrigger';
+export * from './apiGateway';

--- a/packages/serverless-contracts/src/contracts/apiGateway/types/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/lambdaHandler.ts
@@ -1,20 +1,12 @@
 import type {
-  APIGatewayEventRequestContextJWTAuthorizer,
-  APIGatewayEventRequestContextLambdaAuthorizer,
   APIGatewayEventRequestContextV2WithAuthorizer,
   APIGatewayEventRequestContextWithAuthorizer,
-  APIGatewayProxyCallback,
-  APIGatewayProxyCallbackV2,
-  APIGatewayProxyCognitoAuthorizer,
-  APIGatewayProxyEventBase,
-  APIGatewayProxyEventV2WithRequestContext,
-  APIGatewayProxyResult,
-  APIGatewayProxyResultV2,
   Callback,
   Context,
 } from 'aws-lambda';
 
 import { GenericApiGatewayContract } from '../apiGatewayContract';
+import { AuthorizerContext } from './authorizerContext';
 import {
   BodyType,
   CustomRequestContextType,
@@ -28,16 +20,6 @@ import {
   ApiGatewayIntegrationType,
 } from './constants';
 import { DefinedProperties } from './utils';
-
-type AuthorizerContext<AuthorizerType extends ApiGatewayAuthorizerType> =
-  AuthorizerType extends 'cognito'
-    ? APIGatewayProxyCognitoAuthorizer
-    : AuthorizerType extends 'jwt'
-    ? APIGatewayEventRequestContextJWTAuthorizer
-    : AuthorizerType extends 'lambda'
-    ? // We use unknown for now because we would need another schema to define the authorizer context
-      APIGatewayEventRequestContextLambdaAuthorizer<unknown>
-    : undefined;
 
 export type RequestContext<
   IntegrationType extends ApiGatewayIntegrationType,
@@ -71,10 +53,6 @@ export type HandlerEventType<
   headers: Headers;
   body: Body;
 }>;
-
-type HandlerCallback<IntegrationType> = IntegrationType extends 'restApi'
-  ? APIGatewayProxyCallback
-  : APIGatewayProxyCallbackV2;
 
 /**
  * The **internal** type of a Swarmion handler, with type-inferred event
@@ -134,51 +112,3 @@ export type SwarmionApiGatewayHandler<
   Output,
   AdditionalArgs
 >;
-
-/**
- * The type of an ApiGateway event. This is the actual event that will
- * be passed to the lambda, not the Swarmion inferred one.
- *
- * See https://docs.aws.amazon.com/lambda/latest/dg/typescript-handler.html.
- */
-export type ApiGatewayEvent<
-  IntegrationType extends ApiGatewayIntegrationType,
-  AuthorizerType extends ApiGatewayAuthorizerType,
-> = IntegrationType extends 'restApi'
-  ? APIGatewayProxyEventBase<AuthorizerContext<AuthorizerType>>
-  : APIGatewayProxyEventV2WithRequestContext<
-      APIGatewayEventRequestContextV2WithAuthorizer<
-        AuthorizerContext<AuthorizerType>
-      >
-    >;
-
-/**
- * The type of an ApiGateway event. This is the actual event that will
- * be passed to the lambda, not the Swarmion inferred one.
- *
- * See https://docs.aws.amazon.com/lambda/latest/dg/typescript-handler.html.
- */
-export type ApiGatewayResult<
-  IntegrationType extends ApiGatewayIntegrationType,
-  Output,
-> = IntegrationType extends 'restApi'
-  ? APIGatewayProxyResult
-  : APIGatewayProxyResultV2<Output>;
-
-/**
- * The type of an ApiGateway handler. This is the actual version that will
- * be executed by the lambda, not the Swarmion inferred one.
- *
- * See https://docs.aws.amazon.com/lambda/latest/dg/typescript-handler.html.
- */
-export type ApiGatewayHandler<
-  IntegrationType extends ApiGatewayIntegrationType,
-  AuthorizerType extends ApiGatewayAuthorizerType,
-  Output,
-  AdditionalArgs extends unknown[] = never[],
-> = (
-  event: ApiGatewayEvent<IntegrationType, AuthorizerType>,
-  context: Context,
-  callback: HandlerCallback<IntegrationType>,
-  ...additionalArgs: AdditionalArgs
-) => Promise<ApiGatewayResult<IntegrationType, Output>>;

--- a/packages/serverless-contracts/src/contracts/apiGateway/types/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/lambdaHandler.ts
@@ -55,6 +55,29 @@ export type HandlerEventType<
 }>;
 
 /**
+ * The type of the event passed as first argument to a Swarmion handler,
+ * The handler function can define additional arguments.
+ */
+export type SwarmionApiGatewayEvent<
+  Contract extends GenericApiGatewayContract,
+  IntegrationType extends ApiGatewayIntegrationType = Contract['integrationType'],
+  AuthorizerType extends ApiGatewayAuthorizerType = Contract['authorizerType'],
+  PathParameters = PathParametersType<Contract>,
+  QueryStringParameters = QueryStringParametersType<Contract>,
+  Headers = HeadersType<Contract>,
+  CustomRequestContext = CustomRequestContextType<Contract>,
+  Body = BodyType<Contract>,
+> = HandlerEventType<
+  IntegrationType,
+  AuthorizerType,
+  PathParameters,
+  QueryStringParameters,
+  Headers,
+  CustomRequestContext,
+  Body
+>;
+
+/**
  * The **internal** type of a Swarmion handler, with type-inferred event
  * The handler function can define additional arguments.
  *


### PR DESCRIPTION
Not sure about the addition in unit tests in addition to the type test, I can remove it