### PR TITLE
perf(serverless-contracts): move ajv schema compilation outside of handler invocation

### DIFF
--- a/packages/serverless-contracts/src/contracts/eventBridge/features/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/eventBridge/features/lambdaHandler.ts
@@ -17,23 +17,29 @@ export const getEventBridgeHandler =
   ) =>
   <AdditionalArgs extends unknown[] = []>(
     handler: SwarmionEventBridgeHandler<EventType, Payload, AdditionalArgs>,
-  ): EventBridgeHandler<EventType, Payload, AdditionalArgs> =>
-  async (event, context, callback, ...additionalArgs: AdditionalArgs) => {
+  ): EventBridgeHandler<EventType, Payload, AdditionalArgs> => {
     const ajv = new Ajv();
-
     const payloadValidator = ajv.compile(contract.payloadSchema);
-    if (!payloadValidator(event.detail)) {
-      console.error('Error: Invalid payload');
-      console.error(payloadValidator.errors);
-      throw new Error('Invalid payload');
-    }
 
-    const handlerResponse = await handler(
+    return async (
       event,
       context,
       callback,
-      ...additionalArgs,
-    );
+      ...additionalArgs: AdditionalArgs
+    ) => {
+      if (!payloadValidator(event.detail)) {
+        console.error('Error: Invalid payload');
+        console.error(payloadValidator.errors);
+        throw new Error('Invalid payload');
+      }
 
-    return handlerResponse;
+      const handlerResponse = await handler(
+        event,
+        context,
+        callback,
+        ...additionalArgs,
+      );
+
+      return handlerResponse;
+    };
   };


### PR DESCRIPTION
This change allows to compile the schema only once, instead of compiling it on every invocation.
On handlers with basic schemas, this change reduces the execution by around 5ms.
With larger schemas, the difference is even more significant.
