### PR TITLE
feat(nx-plugin): add qualifier to cdk generator

### DIFF
--- a/packages/nx-plugin/schemas/cdk-service/files/cdk.json__tmpl__
+++ b/packages/nx-plugin/schemas/cdk-service/files/cdk.json__tmpl__
@@ -2,7 +2,9 @@
   "app": "npx ts-node --prefer-ts-exts resources/index.ts",
   "requireApproval": "never",
   "watch": {
-    "include": ["**"],
+    "include": [
+      "**"
+    ],
     "exclude": [
       "coverage",
       "project.json",
@@ -18,7 +20,9 @@
       "node_modules"
     ]
   },
+  "toolkitStackName": "CDKToolkit<%= projectClassName %>",
   "context": {
+    "@aws-cdk/core:bootstrapQualifier": "<%= hashedProjectName %>",
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
     "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
@@ -36,6 +40,9 @@
     "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
     "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
     "@aws-cdk/core:enablePartitionLiterals": true,
-    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"]
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/packages/nx-plugin/src/generators/cdk-service/typed-json-config/package.json.ts
+++ b/packages/nx-plugin/src/generators/cdk-service/typed-json-config/package.json.ts
@@ -6,9 +6,9 @@ export const packageJson = (options: NormalizedSchema): PackageJson => ({
   version: '1.0.0',
   license: 'UNLICENSED',
   scripts: {
-    bootstrap: `cdk bootstrap --profile ${options.workspaceName}-developer`,
-    'bootstrap-production': 'cdk bootstrap --context stage=production',
-    'bootstrap-staging': 'cdk bootstrap --context stage=staging',
+    bootstrap: `cdk bootstrap --profile ${options.workspaceName}-developer --qualifier ${options.hashedProjectName}`,
+    'bootstrap-production': `cdk bootstrap --context stage=production --qualifier ${options.hashedProjectName}`,
+    'bootstrap-staging': `cdk bootstrap --context stage=staging --qualifier ${options.hashedProjectName}`,
     deploy: `cdk deploy --profile ${options.workspaceName}-developer`,
     'deploy-production': 'cdk deploy --context stage=production',
     'deploy-staging': 'cdk deploy --context stage=staging',

--- a/packages/nx-plugin/src/generators/helpers/normalizeOptions.ts
+++ b/packages/nx-plugin/src/generators/helpers/normalizeOptions.ts
@@ -5,6 +5,7 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { Linter } from '@nrwl/linter';
+import { createHash } from 'crypto';
 import { relative } from 'path';
 
 import { GeneratorType, NormalizedSchema, Schema } from '../types';
@@ -30,10 +31,17 @@ export const normalizeOptions = (
   const { npmScope } = getWorkspaceLayout(tree);
   const offsetFromRoot = relative(packageRoot, tree.root);
 
+  // hashed project name is a 10 char string
+  const hashedProjectName = createHash('sha512')
+    .update(projectName)
+    .digest('base64')
+    .slice(0, 10);
+
   return {
     ...options,
     projectClassName: className,
     projectPropertyName: propertyName,
+    hashedProjectName,
     generatorType,
     importPath: projectName,
     linter,

--- a/packages/nx-plugin/src/generators/types/Shema.ts
+++ b/packages/nx-plugin/src/generators/types/Shema.ts
@@ -10,6 +10,7 @@ export interface Schema {
 export interface NormalizedSchema extends Schema {
   projectClassName: string;
   projectPropertyName: string;
+  hashedProjectName: string;
   generatorType: GeneratorType;
   importPath: string;
   linter: Linter;


### PR DESCRIPTION
fixes #491 

The idea of this fix is:
- each stack gets its bootstrap stack named `CDKToolkit{projectName}`
- each bootstrap stack uses a `qualifier` to ensure resources won't clash
- this `qualifier` must be explicitely passed to `cdk bootstrap`, otherwise it is not applied
- this `qualifier` must be less than 10 chars, so a SHA1 hash is enough

See https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html