### PR TITLE
feat(nx-plugin): use resourceForPath for CDK construct

### DIFF
--- a/packages/nx-plugin/schemas/cdk-service/files/contracts/healthContract.ts__tmpl__
+++ b/packages/nx-plugin/schemas/cdk-service/files/contracts/healthContract.ts__tmpl__
@@ -3,7 +3,7 @@ import { ApiGatewayContract } from '@swarmion/serverless-contracts';
 // move this contract to a shared library once you need to use it outside this service
 export const healthContract = new ApiGatewayContract({
   id: '<%= name %>-health',
-  path: 'health',
+  path: '/health',
   method: 'GET',
   integrationType: 'restApi',
   outputSchema: {

--- a/packages/nx-plugin/schemas/cdk-service/files/functions/health/config.ts__tmpl__
+++ b/packages/nx-plugin/schemas/cdk-service/files/functions/health/config.ts__tmpl__
@@ -16,8 +16,6 @@ export class Health extends Construct {
   constructor(scope: Construct, id: string, { restApi }: HealthProps) {
     super(scope, id);
 
-    const healthResource = restApi.root.addResource(healthContract.path);
-
     this.healthFunction = new NodejsFunction(this, 'Lambda', {
       entry: getCdkHandlerPath(__dirname),
       handler: 'main',
@@ -27,9 +25,11 @@ export class Health extends Construct {
       bundling: sharedCdkEsbuildConfig,
     });
 
-    healthResource.addMethod(
-      healthContract.method,
-      new LambdaIntegration(this.healthFunction),
-    );
+    restApi.root
+      .resourceForPath(healthContract.path)
+      .addMethod(
+        healthContract.method,
+        new LambdaIntegration(this.healthFunction),
+      );
   }
 }


### PR DESCRIPTION
Using `resourceForPath` is much more scalable than `addResource` because:
- it can add nested paths (e.g. `/toto/tata/{tataId}`)
- it supports a path beginning with `/`