### PR TITLE
fix(nx-plugin): use safe base64url for qualifier

### DIFF
--- a/packages/nx-plugin/src/generators/helpers/normalizeOptions.ts
+++ b/packages/nx-plugin/src/generators/helpers/normalizeOptions.ts
@@ -34,7 +34,7 @@ export const normalizeOptions = (
   // hashed project name is a 10 char string
   const hashedProjectName = createHash('sha512')
     .update(projectName)
-    .digest('base64')
+    .digest('base64url')
     .slice(0, 10)
     .toLowerCase();
 


### PR DESCRIPTION
I got an error when bootstraping a new stack due to the presence of `/` in the qualifier. It is safer if we use a `base64url` instead of `base64`. See [this stackoverflow](https://stackoverflow.com/questions/55389211/string-based-data-encoding-base64-vs-base64url) for detailed differences.

Also I have checked that `-` is safe in a qualifier.