### PR TITLE
feat(serverless-contracts): add an optional arg in getHandler to disable input/output validation

### DIFF
--- a/packages/serverless-contracts/src/contracts/eventBridge/__tests__/lambdaHandler.test.ts
+++ b/packages/serverless-contracts/src/contracts/eventBridge/__tests__/lambdaHandler.test.ts
@@ -65,6 +65,27 @@ describe('EventBridgeContract handler test', () => {
     ).rejects.toThrowError();
   });
 
+  it('should not throw it the payload is invalid but validation is disabled in optinos', async () => {
+    const handler = getHandler(eventBridgeContract, { validatePayload: false })(
+      async event => {
+        await Promise.resolve();
+
+        return event.detail;
+      },
+    );
+
+    const result = await handler(
+      {
+        ...baseEvent,
+        // @ts-expect-error this is a test
+        detail: { tata: 'toto' },
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toEqual({ tata: 'toto' });
+  });
+
   it('should accept additional arguments', async () => {
     const mockSideEffect = vitest.fn(() => 'tata');
     interface SideEffects {

--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
@@ -241,6 +241,22 @@ const handler = getHandler(myContract)(async event => {
 });
 ```
 
+:::info
+By default, the `getHandler` feature will validate both the input and the output of your lambda. If you wish to disable one of those, you can use the optional second argument in the `getHandler` feature:
+
+```ts
+import { getHandler } from '@swarmion/serverless-contracts';
+
+const handler = getHandler(myContract, {
+  validateInput: false,
+  validateOutput: false,
+})(async event => {
+  // ...
+});
+```
+
+:::
+
 ### Use Middy middlewares
 
 `ApiGatewayContract` is compatible with middy. For example, if you wish to use Middy for Cors and logging:

--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/2-eventbridge.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/2-eventbridge.md
@@ -90,6 +90,19 @@ export const main = getHandler(myEventBridgeContract)(async event => {
 
 :::caution
 This handler also provides a payload validation that will throw an error if there is a mismatch with the `payloadSchema`. This ensure that invalid events will not be mistakenly taken into account. However, be sure to set up an invalid events failure flow, for example with a [Lambda `onFailure` destination](https://www.serverless.com/blog/lambda-destinations/).
+
+If you still wish to disable this behavior, you can use the optional second argument in the `getHandler` feature:
+
+```ts
+import { getHandler } from '@swarmion/serverless-contracts';
+
+const handler = getHandler(myContract, {
+  validatePayload: false,
+})(async event => {
+  // ...
+});
+```
+
 :::
 
 ## Provider-side usage


### PR DESCRIPTION
fix #507 