### PR TITLE
fix(serverless-contracts): remove mock handler export

### DIFF
--- a/packages/serverless-contracts/src/contracts/apiGateway/index.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/index.ts
@@ -7,7 +7,8 @@ export {
   getLambdaHandler,
   getApiGatewayHandler,
   getRequestParameters,
-  getMockHandlerInput,
-  setMockHandlerInputSeed,
+  // TODO add this back. For context, see https://github.com/swarmion/swarmion/issues/527
+  // getMockHandlerInput,
+  // setMockHandlerInputSeed,
 } from './features';
 export type { SwarmionApiGatewayHandler, ApiGatewayHandler } from './types';


### PR DESCRIPTION
See #527 