### PR TITLE
feat: add tests workflow to merge group check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,8 @@
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
 
 # cancel previous runs on the same PR
 concurrency:


### PR DESCRIPTION
fixes #532 

- Add a check on `merge_group` event as suggested in the [merge queue documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#:~:text=update%20your%20CI%20configuration%20to%20trigger%20and%20report%20on%20merge%20group%20events)

The `validate-pr` job of the `PR Tests` workflow is the only required check

