### PR TITLE
examples: remove useless postinstall variable check

### DIFF
--- a/examples/swarmion-bare/package.json
+++ b/examples/swarmion-bare/package.json
@@ -19,7 +19,7 @@
     "lint-fix": "eslint --ext=js,ts --fix",
     "lint-fix-all": "nx run-many --target=lint-fix-all --all --parallel=4",
     "package": "nx run-many --target=package --all --parallel=4",
-    "postinstall": "test -n \"$NO_PNPM_POSTINSTALL\" && syncpack format || husky install && syncpack format",
+    "postinstall": "husky install && syncpack format",
     "test": "nx run-many --targets=test-circular,test-linter,test-type,test-unit --all --parallel=4",
     "test-affected": "nx affected --targets=test-circular,test-linter,test-type,test-unit",
     "test-circular": "nx run-many --target=test-circular --all --parallel=4",

--- a/examples/swarmion-full-stack/package.json
+++ b/examples/swarmion-full-stack/package.json
@@ -20,7 +20,7 @@
     "lint-fix-all": "nx run-many --target=lint-fix-all --all --parallel=4",
     "linter-base-config": "eslint",
     "package": "nx run-many --target=package --all --parallel=4",
-    "postinstall": "test -n \"$NO_PNPM_POSTINSTALL\" && syncpack format || husky install && syncpack format",
+    "postinstall": "husky install && syncpack format",
     "test": "nx run-many --targets=test-circular,test-linter,test-type,test-unit --all --parallel=4",
     "test-affected": "nx affected --targets=test-circular,test-linter,test-type,test-unit",
     "test-circular": "nx run-many --target=test-circular --all --parallel=4",

--- a/examples/swarmion-starter/package.json
+++ b/examples/swarmion-starter/package.json
@@ -19,7 +19,7 @@
     "lint-fix": "eslint --ext=js,ts --fix",
     "lint-fix-all": "nx run-many --target=lint-fix-all --all --parallel=4",
     "package": "nx run-many --target=package --all --parallel=4",
-    "postinstall": "test -n \"$NO_PNPM_POSTINSTALL\" && syncpack format || husky install && syncpack format",
+    "postinstall": "husky install && syncpack format",
     "test": "nx run-many --targets=test-circular,test-linter,test-type,test-unit --all --parallel=4",
     "test-affected": "nx affected --targets=test-circular,test-linter,test-type,test-unit",
     "test-circular": "nx run-many --target=test-circular --all --parallel=4",

--- a/examples/swarmion-with-next/package.json
+++ b/examples/swarmion-with-next/package.json
@@ -20,7 +20,7 @@
     "lint-fix": "eslint --ext=js,ts --fix",
     "lint-fix-all": "nx run-many --target=lint-fix-all --all --parallel=4",
     "package": "nx run-many --target=package --all --parallel=4",
-    "postinstall": "test -n \"$NO_PNPM_POSTINSTALL\" && syncpack format || husky install && syncpack format",
+    "postinstall": "husky install && syncpack format",
     "test": "nx run-many --targets=test-circular,test-linter,test-type,test-unit --all --parallel=4",
     "test-affected": "nx affected --targets=test-circular,test-linter,test-type,test-unit",
     "test-circular": "nx run-many --target=test-circular --all --parallel=4",

--- a/scripts/check-example.sh
+++ b/scripts/check-example.sh
@@ -15,7 +15,7 @@ if [[ "$REF" == "" ]]; then
     exit 1
 fi
 
-NO_PNPM_POSTINSTALL=true pnpm node packages/create-swarmion-app/dist/index.js -t $EXAMPLE -s $REF $TEMP_DIR/$EXAMPLE_NAME
+HUSKY=0 pnpm node packages/create-swarmion-app/dist/index.js -t $EXAMPLE -s $REF $TEMP_DIR/$EXAMPLE_NAME
 cd $TEMP_DIR/$EXAMPLE_NAME
 
 # test everything


### PR DESCRIPTION
It was needed only when running install inside the Swarmion repo,
so it should not present in the examples files that will be downloaded.
Using `HUSKY=0` when running commands triggering `postinstall` does the trick.
