### PR TITLE
feat(serverless-contracts): make serverless and axios optional peerdeps

### DIFF
--- a/packages/serverless-contracts/package.json
+++ b/packages/serverless-contracts/package.json
@@ -85,7 +85,7 @@
   },
   "peerDependencies": {
     "@serverless/typescript": ">=3",
-    "axios": "^1.2.2"
+    "axios": ">=1"
   },
   "peerDependenciesMeta": {
     "@serverless/typescript": {

--- a/packages/serverless-contracts/package.json
+++ b/packages/serverless-contracts/package.json
@@ -86,5 +86,13 @@
   "peerDependencies": {
     "@serverless/typescript": ">=3",
     "axios": "^1.2.2"
+  },
+  "peerDependenciesMeta": {
+    "@serverless/typescript": {
+      "optional": true
+    },
+    "axios": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
With pnpm, A peerDependency error will be triggered if the consumer has an incompatible version of one of the peerDependencies.