### PR TITLE
fix(bare template): remove unnecessary workspaces

### DIFF
--- a/examples/swarmion-bare/package.json
+++ b/examples/swarmion-bare/package.json
@@ -4,9 +4,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "workspaces": [
-    "contracts/*",
-    "packages/*",
-    "services/*"
+    "packages/*"
   ],
   "scripts": {
     "build": "nx run-many --target=build --all --parallel=4",


### PR DESCRIPTION
Hey I add an error with ESLint import rule when I created a project from `bare`. It couldn't find a contracts directory because it wasn't created.
This fixed for me