### PR TITLE
chore(serverless-configuration): fix apiGatewayCorsAllowedOrigins

### DIFF
--- a/packages/serverless-configuration/src/sharedConfig.ts
+++ b/packages/serverless-configuration/src/sharedConfig.ts
@@ -44,7 +44,7 @@ export const sharedProviderConfig: ServerlessProviderConfig = {
 export const sharedParams = {
   dev: {
     profile: 'swarmion-developer',
-    apiGatewayCorsAllowedOrigins: ['localhost:3000'],
+    apiGatewayCorsAllowedOrigins: ['http://localhost:3000'],
   },
   staging: { profile: '', apiGatewayCorsAllowedOrigins: [] },
   production: { profile: '', apiGatewayCorsAllowedOrigins: [] },


### PR DESCRIPTION
`http://` is mandatory in CORS to deploy httpApi

fix https://github.com/swarmion/swarmion/issues/582