### PR TITLE
Fix #587

### DIFF
--- a/contracts/orchestrator-contracts/tsup.config.ts
+++ b/contracts/orchestrator-contracts/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/examples/swarmion-bare/packages/serverless-configuration/tsup.config.ts
+++ b/examples/swarmion-bare/packages/serverless-configuration/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/examples/swarmion-full-stack/contracts/core-contracts/tsup.config.ts
+++ b/examples/swarmion-full-stack/contracts/core-contracts/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/examples/swarmion-full-stack/contracts/users-contracts/tsup.config.ts
+++ b/examples/swarmion-full-stack/contracts/users-contracts/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/examples/swarmion-full-stack/frontend/shared/tsup.config.ts
+++ b/examples/swarmion-full-stack/frontend/shared/tsup.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/examples/swarmion-full-stack/packages/serverless-configuration/tsup.config.ts
+++ b/examples/swarmion-full-stack/packages/serverless-configuration/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/examples/swarmion-starter/contracts/core-contracts/tsup.config.ts
+++ b/examples/swarmion-starter/contracts/core-contracts/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/examples/swarmion-starter/packages/serverless-configuration/tsup.config.ts
+++ b/examples/swarmion-starter/packages/serverless-configuration/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/examples/swarmion-with-next/contracts/core-contracts/tsup.config.ts
+++ b/examples/swarmion-with-next/contracts/core-contracts/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/examples/swarmion-with-next/packages/serverless-configuration/tsup.config.ts
+++ b/examples/swarmion-with-next/packages/serverless-configuration/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/packages/eslint-plugin/tsup.config.ts
+++ b/packages/eslint-plugin/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/packages/nx-plugin/schemas/library/files/tsup.config.ts__tmpl__
+++ b/packages/nx-plugin/schemas/library/files/tsup.config.ts__tmpl__
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/packages/nx-plugin/tsup.config.ts
+++ b/packages/nx-plugin/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/packages/serverless-cdk-plugin/tsup.config.ts
+++ b/packages/serverless-cdk-plugin/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/packages/serverless-configuration/tsup.config.ts
+++ b/packages/serverless-configuration/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/packages/serverless-contracts-plugin/tsup.config.ts
+++ b/packages/serverless-contracts-plugin/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/packages/serverless-contracts/tsup.config.ts
+++ b/packages/serverless-contracts/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/packages/serverless-helpers/tsup.config.ts
+++ b/packages/serverless-helpers/tsup.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  clean: true,
   silent: true,
   format: ['cjs', 'esm'],
   outDir: 'dist',

--- a/user-docs/documentation/docs/how-to-guides/3-migration-guides/2-babel-to-tsup.md
+++ b/user-docs/documentation/docs/how-to-guides/3-migration-guides/2-babel-to-tsup.md
@@ -48,7 +48,6 @@ Then, in each built package:
 
   export default defineConfig({
     entry: ['src/index.ts'],
-    clean: true,
     silent: true,
     format: ['cjs', 'esm'],
     outExtension: ctx => {


### PR DESCRIPTION
- chore: prevent dist folder from being deleted when running the watch command
- feat(nx-plugin): prevent dist folder from being deleted when running the watch command
- examples: prevent dist folder from being deleted when running the watch command
