### PR TITLE
fix(nx-plugin): create hashedProjectName without special characters

### DIFF
--- a/packages/nx-plugin/src/generators/helpers/normalizeOptions.ts
+++ b/packages/nx-plugin/src/generators/helpers/normalizeOptions.ts
@@ -34,9 +34,8 @@ export const normalizeOptions = (
   // hashed project name is a 10 char string
   const hashedProjectName = createHash('sha512')
     .update(projectName)
-    .digest('base64url')
-    .slice(0, 10)
-    .toLowerCase();
+    .digest('hex') // use hex to get a hash without special chars [a-z0-9]. Special chars break some CDK features
+    .slice(0, 10);
 
   return {
     ...options,


### PR DESCRIPTION
fix https://github.com/swarmion/swarmion/issues/615

use `hex` encoding to create a `hashedProjectName` that matches `/^[a-z0-9]{10}$/` and avoid side effects caused by not supported special characters 