### PR TITLE
fix(serverless-contracts): combine baseUrl and path correctly in fetchRequests

### DIFF
--- a/packages/serverless-contracts/src/contracts/apiGateway/features/fetchRequest.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/features/fetchRequest.ts
@@ -2,6 +2,7 @@
 
 import { GenericApiGatewayContract } from '../apiGatewayContract';
 import { OutputType, RequestArguments } from '../types';
+import { combineUrls } from '../utils';
 import { getRequestParameters } from './requestParameters';
 
 export const getFetchRequest = async <
@@ -18,7 +19,7 @@ export const getFetchRequest = async <
   const searchString = new URLSearchParams(queryStringParameters).toString();
 
   if (options.baseUrl !== undefined) {
-    url = new URL(path, options.baseUrl);
+    url = combineUrls(path, options.baseUrl);
 
     url.search = searchString;
   } else {

--- a/packages/serverless-contracts/src/contracts/apiGateway/utils/__tests__/combineUrls.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/utils/__tests__/combineUrls.test.ts
@@ -1,0 +1,30 @@
+import { combineUrls } from '../combineUrls';
+
+const expectedUrl = new URL('https://example.com/base/path');
+
+describe('combineUrls', () => {
+  it.each([
+    {
+      baseUrl: 'https://example.com/base',
+      path: '/path',
+    },
+    {
+      baseUrl: 'https://example.com/base',
+      path: 'path',
+    },
+    {
+      baseUrl: 'https://example.com/base/',
+      path: '/path',
+    },
+    {
+      baseUrl: 'https://example.com/base/',
+      path: 'path',
+    },
+  ])(
+    'should combine $baseUrl and $path into $expected',
+    ({ baseUrl, path }) => {
+      expect(combineUrls(path, baseUrl)).toEqual(expectedUrl);
+      expect(combineUrls(path, new URL(baseUrl))).toEqual(expectedUrl);
+    },
+  );
+});

--- a/packages/serverless-contracts/src/contracts/apiGateway/utils/combineUrls.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/utils/combineUrls.ts
@@ -1,0 +1,8 @@
+export const combineUrls = (path: string, baseUrl: string | URL): URL => {
+  const stringBaseUrl = baseUrl instanceof URL ? baseUrl.toString() : baseUrl;
+
+  const pathWithoutLeadingSlash = path.replace(/^\/+/, '');
+  const baseUrlWithTrailingSlash = stringBaseUrl.replace(/\/+$/, '') + '/';
+
+  return new URL(pathWithoutLeadingSlash, baseUrlWithTrailingSlash);
+};

--- a/packages/serverless-contracts/src/contracts/apiGateway/utils/index.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './apiGatewayProxyTransformers';
 export * from './convertJsonSchemaToValidOAS3';
+export * from './combineUrls';


### PR DESCRIPTION
this is a fix proposal for issue #464, based on the url combining used by axios