### PR TITLE
Add better credentials plugin to orchestrator service

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,6 +853,9 @@ importers:
       serverless-analyze-bundle-plugin:
         specifier: ^2.0.0
         version: 2.0.1(serverless@3.27.0)
+      serverless-better-credentials:
+        specifier: ^1.1.3
+        version: 1.1.3(@serverless/utils@6.8.2)(aws-sdk@2.1304.0)(serverless@3.27.0)
       serverless-custom-iam-roles-per-function:
         specifier: ^1.0.1
         version: 1.0.1
@@ -17386,6 +17389,20 @@ packages:
     dependencies:
       esbuild-visualizer: 0.4.0
       node-stream-zip: 1.15.0
+      open: 8.4.1
+      serverless: 3.27.0
+    dev: true
+
+  /serverless-better-credentials@1.1.3(@serverless/utils@6.8.2)(aws-sdk@2.1304.0)(serverless@3.27.0):
+    resolution: {integrity: sha512-specJ3DH70DkstDo0NibL7rETHdrMQ6RLbL1lz0ijjmx6fuV/8XAd6StxoNoXoCCbTT0lXU+OIlfDiyivuca6A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@serverless/utils': ^6.0.2
+      aws-sdk: ^2.567.0
+      serverless: ^2 || ^3
+    dependencies:
+      '@serverless/utils': 6.8.2
+      aws-sdk: 2.1304.0
       open: 8.4.1
       serverless: 3.27.0
     dev: true

--- a/services/orchestrator/package.json
+++ b/services/orchestrator/package.json
@@ -48,6 +48,7 @@
     "node-fetch": "^3.3.0",
     "serverless": "^3.27.0",
     "serverless-analyze-bundle-plugin": "^2.0.0",
+    "serverless-better-credentials": "^1.1.3",
     "serverless-custom-iam-roles-per-function": "^1.0.1",
     "serverless-esbuild": "^1.33.2",
     "serverless-iam-roles-per-function": "^3.2.0",

--- a/services/orchestrator/serverless.ts
+++ b/services/orchestrator/serverless.ts
@@ -25,6 +25,7 @@ const serverlessConfiguration: AWS &
   frameworkVersion,
   configValidationMode: 'error',
   plugins: [
+    'serverless-better-credentials',
     'serverless-esbuild',
     '@swarmion/serverless-cdk-plugin',
     '@swarmion/serverless-plugin',


### PR DESCRIPTION
Should we also add it to the examples ? Or is it not worth it ?


![image](https://user-images.githubusercontent.com/19265358/233668603-2dcdb511-9fe0-4fe4-8ddd-7a9c42bfcc8e.png)
