### PR TITLE
ci: do not run 'validate' jobs if the workflow is cancelled

### DIFF
--- a/.github/workflows/pr-check-examples.yml
+++ b/.github/workflows/pr-check-examples.yml
@@ -82,7 +82,7 @@ jobs:
   validate-examples:
     name: 📝 Validate examples
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}
     needs: [check-if-job-should-run, check-examples]
     steps:
       - name: Validate check examples

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -82,7 +82,7 @@ jobs:
   validate-pr:
     name: ✅ Validate the PR
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}
     needs: [build-format-lint, build, unit-tests-and-sonar]
     steps:
       - name: Validate build-format-lint

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -71,7 +71,7 @@ jobs:
   validate-tests:
     name: ✅ Validate that tests have passed
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}
     needs: [build-format-lint, build, unit-tests-and-sonar]
     steps:
       - name: Validate build-format-lint


### PR DESCRIPTION
Whenever a workflow is manually cancelled, this makes more sense to not run the validation jobs. Also, if these were successful, a deployment could be trigerred while the workflow was cancelled.