### PR TITLE
fix: remove aws-cdk-lib as peer dependency

### DIFF
--- a/packages/serverless-helpers/package.json
+++ b/packages/serverless-helpers/package.json
@@ -63,7 +63,6 @@
     "vitest": "0.30.0"
   },
   "peerDependencies": {
-    "@serverless/typescript": ">=3",
-    "aws-cdk-lib": "^2.60.0"
+    "@serverless/typescript": ">=3"
   }
 }


### PR DESCRIPTION
Having this as a peer dependency means that it is packaged in your lambda functions. Adds almost 20mb to your lambda package size. Not ideal :(