### PR TITLE
feat: add header parameters to open api documentation generation

### DIFF
--- a/packages/serverless-contracts/src/contracts/apiGateway/__tests__/openApiDocumentation.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__tests__/openApiDocumentation.test.ts
@@ -52,7 +52,7 @@ describe('apiGateway openApi contract documentation', () => {
     [HttpStatusCodes.UNAUTHORIZED]: unauthorizedSchema,
   };
 
-  describe('hhtpApi, when all parameters are set', () => {
+  describe('httpApi, when all parameters are set', () => {
     const httpApiContract = new ApiGatewayContract({
       id: 'testContract',
       path: '/users/{userId}',
@@ -71,6 +71,14 @@ describe('apiGateway openApi contract documentation', () => {
         method: 'get',
         documentation: {
           parameters: [
+            {
+              in: 'header',
+              name: 'myHeader',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
             {
               in: 'query',
               name: 'testId',

--- a/packages/serverless-contracts/src/contracts/apiGateway/features/openApiDocumentation.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/features/openApiDocumentation.ts
@@ -80,6 +80,21 @@ export const getContractDocumentation = <
     ];
   }
 
+  if (contract.headersSchema?.properties !== undefined) {
+    contractDocumentation.parameters = [
+      ...Object.entries(contract.headersSchema.properties).map(
+        ([variableName, variableDefinition]) => ({
+          name: variableName,
+          in: 'header',
+          schema: convertJsonSchemaToValidOAS3(variableDefinition),
+          required:
+            contract.headersSchema?.required?.includes(variableName) ?? false,
+        }),
+      ),
+      ...(contractDocumentation.parameters ?? []),
+    ];
+  }
+
   if (contract.bodySchema !== undefined) {
     contractDocumentation.requestBody = {
       content: {

--- a/packages/serverless-contracts/src/features/__tests__/openApiDocumentation.test.ts
+++ b/packages/serverless-contracts/src/features/__tests__/openApiDocumentation.test.ts
@@ -173,6 +173,14 @@ describe('openApi service documentation', () => {
               },
               parameters: [
                 {
+                  in: 'header',
+                  name: 'myHeader',
+                  required: true,
+                  schema: {
+                    type: 'string',
+                  },
+                },
+                {
                   name: 'userId',
                   in: 'path',
                   schema: { type: 'string' },


### PR DESCRIPTION
Hello guys!
I'd like to use the header params in the Swagger docs, so i added this little addition to your code.
Hopefully you guys won't mind it!