### PR TITLE
fix(lodash): enforce lodash imports to use .js extension

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,11 +84,13 @@ module.exports = {
     'no-restricted-imports': [
       'error',
       {
-        paths: [
+        patterns: [
           {
-            name: 'lodash',
-            message: 'Please use lodash/{module} import instead',
+            group: ['$lodash^', 'lodash/*', '!lodash/*.js'],
+            message: 'Please use lodash/{module}.js import instead',
           },
+        ],
+        paths: [
           {
             name: 'aws-sdk',
             message: 'Please use aws-sdk/{module} import instead',

--- a/packages/serverless-cdk-plugin/src/serverlessCdk.ts
+++ b/packages/serverless-cdk-plugin/src/serverlessCdk.ts
@@ -1,5 +1,5 @@
 import { App, Stack } from 'aws-cdk-lib';
-import merge from 'lodash/merge';
+import merge from 'lodash/merge.js';
 import * as Serverless from 'serverless';
 import * as Plugin from 'serverless/classes/Plugin';
 import { O } from 'ts-toolbelt';

--- a/packages/serverless-contracts-plugin/src/plugin/utils/listLocalContractSchemas.ts
+++ b/packages/serverless-contracts-plugin/src/plugin/utils/listLocalContractSchemas.ts
@@ -1,7 +1,7 @@
 import { JSONSchema } from 'json-schema-to-ts';
-import isUndefined from 'lodash/isUndefined';
-import mapValues from 'lodash/mapValues';
-import omitBy from 'lodash/omitBy';
+import isUndefined from 'lodash/isUndefined.js';
+import mapValues from 'lodash/mapValues.js';
+import omitBy from 'lodash/omitBy.js';
 import Serverless from 'serverless';
 
 import { getContractFullSchema } from '@swarmion/serverless-contracts';

--- a/packages/serverless-contracts/codspeed-variance.md
+++ b/packages/serverless-contracts/codspeed-variance.md
@@ -1,0 +1,37 @@
+## Without optimization
+
+```
+op run -- pnpm ts-node scripts/analyzeVariance.ts swarmion/swarmion 8bbec52165d0f8fe136d1ddd33bae57f9fbe8b07
+Found 21 runs for swarmion/swarmion (8bbec52165d0f8fe136d1ddd33bae57f9fbe8b07)
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬────────────┬───────────────────┬─────────────────────┬────────────┬──────────────────┐
+│                                                                       (index)                                                                        │  average   │ standardDeviation │ varianceCoefficient │   range    │ rangeCoefficient │
+├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────┼─────────────────────┼────────────┼──────────────────┤
+│       packages/serverless-contracts/src/contracts/eventBridge/__benches__/bigEventBridgeHandler.bench.ts::EventBridge::big handler::invocation       │ '228.4 µs' │     '10.7 µs'     │       '4.7%'        │ '24.6 µs'  │     '10.8%'      │
+│   packages/serverless-contracts/src/contracts/eventBridge/__benches__/bigEventBridgeHandler.bench.ts::EventBridge::big handler::bundled cold start   │  '1.3 s'   │     '37.4 ms'     │       '2.9%'        │  '90 ms'   │      '6.9%'      │
+│    packages/serverless-contracts/src/contracts/apiGateway/__benches__/basicHttpApiHandler.bench.ts::ApiGateway::basic handler::bundled cold start    │ '842.9 ms' │     '7.2 ms'      │       '0.9%'        │ '37.1 ms'  │      '4.4%'      │
+│   packages/serverless-contracts/src/contracts/apiGateway/__benches__/bigHttpApiHandler.bench.ts::ApiGateway::big handler::basic handler invocation   │ '650.3 µs' │     '1.2 µs'      │       '0.2%'        │  '5.1 µs'  │      '0.8%'      │
+│        packages/serverless-contracts/src/contracts/eventBridge/__benches__/basicEventBridge.bench.ts::EventBridge::basic handler::invocation         │ '72.3 µs'  │    '118.9 ns'     │       '0.2%'        │ '475.6 ns' │      '0.7%'      │
+│ packages/serverless-contracts/src/contracts/apiGateway/__benches__/basicHttpApiHandler.bench.ts::ApiGateway::basic handler::basic handler invocation │ '305.5 µs' │    '330.2 ns'     │       '0.1%'        │  '1.2 µs'  │      '0.4%'      │
+│      packages/serverless-contracts/src/contracts/apiGateway/__benches__/bigHttpApiHandler.bench.ts::ApiGateway::big handler::bundled cold start      │  '2.2 s'   │     '1.8 ms'      │       '0.1%'        │  '8.1 ms'  │      '0.4%'      │
+│    packages/serverless-contracts/src/contracts/eventBridge/__benches__/basicEventBridge.bench.ts::EventBridge::basic handler::bundled cold start     │ '690.2 ms' │    '497.3 µs'     │       '0.1%'        │  '1.8 ms'  │      '0.3%'      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────────┴───────────────────┴─────────────────────┴────────────┴──────────────────┘
+```
+
+## With optimization
+
+```
+op run -- pnpm ts-node scripts/analyzeVariance.ts swarmion/swarmion a96bac23d80cb123c3314016dd0c5e907773a766
+Found 21 runs for swarmion/swarmion (a96bac23d80cb123c3314016dd0c5e907773a766)
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬────────────┬───────────────────┬─────────────────────┬────────────┬──────────────────┐
+│                                                                       (index)                                                                        │  average   │ standardDeviation │ varianceCoefficient │   range    │ rangeCoefficient │
+├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────┼─────────────────────┼────────────┼──────────────────┤
+│   packages/serverless-contracts/src/contracts/eventBridge/__benches__/bigEventBridgeHandler.bench.ts::EventBridge::big handler::bundled cold start   │  '1.4 s'   │     '70.6 ms'     │       '5.0%'        │ '355.8 ms' │     '25.1%'      │
+│       packages/serverless-contracts/src/contracts/eventBridge/__benches__/bigEventBridgeHandler.bench.ts::EventBridge::big handler::invocation       │ '216.9 µs' │     '4.2 µs'      │       '1.9%'        │ '19.5 µs'  │      '9.0%'      │
+│    packages/serverless-contracts/src/contracts/apiGateway/__benches__/basicHttpApiHandler.bench.ts::ApiGateway::basic handler::bundled cold start    │ '571.5 ms' │     '7.2 ms'      │       '1.3%'        │ '26.7 ms'  │      '4.7%'      │
+│      packages/serverless-contracts/src/contracts/apiGateway/__benches__/bigHttpApiHandler.bench.ts::ApiGateway::big handler::bundled cold start      │  '2.3 s'   │     '9.7 ms'      │       '0.4%'        │ '40.9 ms'  │      '1.8%'      │
+│ packages/serverless-contracts/src/contracts/apiGateway/__benches__/basicHttpApiHandler.bench.ts::ApiGateway::basic handler::basic handler invocation │ '305.7 µs' │     '1.1 µs'      │       '0.4%'        │  '5.7 µs'  │      '1.9%'      │
+│    packages/serverless-contracts/src/contracts/eventBridge/__benches__/basicEventBridge.bench.ts::EventBridge::basic handler::bundled cold start     │ '462.3 ms' │     '1.2 ms'      │       '0.3%'        │  '3.8 ms'  │      '0.8%'      │
+│   packages/serverless-contracts/src/contracts/apiGateway/__benches__/bigHttpApiHandler.bench.ts::ApiGateway::big handler::basic handler invocation   │ '653.3 µs' │     '1.5 µs'      │       '0.2%'        │  '4.8 µs'  │      '0.7%'      │
+│        packages/serverless-contracts/src/contracts/eventBridge/__benches__/basicEventBridge.bench.ts::EventBridge::basic handler::invocation         │  '73 µs'   │    '109.4 ns'     │       '0.2%'        │ '361.1 ns' │      '0.5%'      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────────┴───────────────────┴─────────────────────┴────────────┴──────────────────┘
+```

--- a/packages/serverless-contracts/src/contracts/apiGateway/apiGatewayContract.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/apiGatewayContract.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { JSONSchema } from 'json-schema-to-ts';
-import isUndefined from 'lodash/isUndefined';
-import omitBy from 'lodash/omitBy';
+import isUndefined from 'lodash/isUndefined.js';
+import omitBy from 'lodash/omitBy.js';
 
 import { ConstrainedJSONSchema } from 'types/constrainedJSONSchema';
 import { HttpMethod, HttpStatusCodes } from 'types/http';

--- a/packages/serverless-contracts/src/contracts/apiGateway/features/fullContractSchema.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/features/fullContractSchema.ts
@@ -1,5 +1,5 @@
-import isUndefined from 'lodash/isUndefined';
-import omitBy from 'lodash/omitBy';
+import isUndefined from 'lodash/isUndefined.js';
+import omitBy from 'lodash/omitBy.js';
 
 import { GenericApiGatewayContract } from '../apiGatewayContract';
 import { FullContractSchemaType } from '../types';

--- a/packages/serverless-contracts/src/contracts/apiGateway/features/openApiDocumentation.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/features/openApiDocumentation.ts
@@ -1,5 +1,5 @@
-import isUndefined from 'lodash/isUndefined';
-import omitBy from 'lodash/omitBy';
+import isUndefined from 'lodash/isUndefined.js';
+import omitBy from 'lodash/omitBy.js';
 import { OpenAPIV3 } from 'openapi-types';
 
 import { ContractOpenApiDocumentation } from 'types/contractOpenApiDocumentation';

--- a/packages/serverless-contracts/src/contracts/apiGateway/features/requestParameters.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/features/requestParameters.ts
@@ -1,5 +1,5 @@
-import isUndefined from 'lodash/isUndefined';
-import omitBy from 'lodash/omitBy';
+import isUndefined from 'lodash/isUndefined.js';
+import omitBy from 'lodash/omitBy.js';
 
 import { fillPathTemplate } from 'utils';
 

--- a/packages/serverless-contracts/src/contracts/apiGateway/utils/convertJsonSchemaToValidOAS3.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/utils/convertJsonSchemaToValidOAS3.ts
@@ -1,8 +1,8 @@
 /*eslint-disable complexity*/
 
 import type { JSONSchema } from 'json-schema-to-ts';
-import cloneDeep from 'lodash/cloneDeep';
-import mapValues from 'lodash/mapValues';
+import cloneDeep from 'lodash/cloneDeep.js';
+import mapValues from 'lodash/mapValues.js';
 import { OpenAPIV3 } from 'openapi-types';
 
 const isArrayOfString = (array: unknown): array is string[] =>


### PR DESCRIPTION
I had the following bug when trying to build my `sst` app:

```
pnpm sst build

Error: Cannot find module '/Users/adrien/projects/swarmion/swarmion/packages/serverless-contracts/node_modules/lodash/isUndefined' imported from /Users/adrien/projects/swarmion/swarmion/packages/serverless-contracts/dist/index.js
Did you mean to import lodash@4.17.21/node_modules/lodash/isUndefined.js?

Trace: Error: Cannot find module '/Users/adrien/projects/swarmion/swarmion/packages/serverless-contracts/node_modules/lodash/isUndefined' imported from /Users/adrien/projects/swarmion/swarmion/packages/serverless-contracts/dist/index.js
Did you mean to import lodash@4.17.21/node_modules/lodash/isUndefined.js?
    at __node_internal_captureLargerStackTrace (node:internal/errors:490:5)
    at new NodeError (node:internal/errors:399:5)
    at finalizeResolution (node:internal/modules/esm/resolve:326:11)
    at moduleResolve (node:internal/modules/esm/resolve:945:10)
    at defaultResolve (node:internal/modules/esm/resolve:1153:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:77:40)
    at link (node:internal/modules/esm/module_job:76:36)
    at process.<anonymous> (file:///Users/adrien/projects/CodSpeedHQ/codspeed/node_modules/.pnpm/sst@2.40.3_typescript@5.3.3/node_modules/sst/cli/sst.js:58:21)
    at process.emit (node:events:525:35)
    at process.emit (node:domain:489:12)
    at process._fatalException (node:internal/process/execution:149:25)
    at processPromiseRejections (node:internal/process/promises:288:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)
```

It seems that the esm node module resolver does not find the `lodash/{module}` entrypoints. Adding the `.js` extension fixes the issue.