### PR TITLE
Feat(serverless-contracts): add SQS contract

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,5 +204,11 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ['**/__tests__/**', '**/*.test.ts?(x)', '**/__benches__/**'],
+      rules: {
+        'max-lines': 0,
+      },
+    },
   ],
 };

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -41,7 +41,7 @@
     "watch": "pnpm clean dist && concurrently 'pnpm:package-* --watch'"
   },
   "dependencies": {
-    "@aws-sdk/client-ssm": "^3.470.0",
+    "@aws-sdk/client-ssm": "^3.540.0",
     "@babel/traverse": "^7.23.6",
     "@babel/types": "^7.23.6",
     "@types/babel__traverse": "^7.20.4",

--- a/packages/serverless-contracts/package.json
+++ b/packages/serverless-contracts/package.json
@@ -49,7 +49,8 @@
     "lodash": "^4.17.21",
     "openapi-types": "12.1.3",
     "seedrandom": "^3.0.5",
-    "ts-toolbelt": "^9.6.0"
+    "ts-toolbelt": "^9.6.0",
+    "ulid": "^2.3.0"
   },
   "devDependencies": {
     "@codspeed/vitest-plugin": "3.1.0",

--- a/packages/serverless-contracts/package.json
+++ b/packages/serverless-contracts/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-eventbridge": "^3.540.0",
+    "@aws-sdk/client-sqs": "^3.540.0",
     "@swarmion/serverless-helpers": "^0.31.3",
     "@types/aws-lambda": "^8.10.130",
     "@types/http-errors": "^2.0.4",

--- a/packages/serverless-contracts/package.json
+++ b/packages/serverless-contracts/package.json
@@ -38,7 +38,7 @@
     "watch": "pnpm clean && concurrently 'pnpm:package-* --watch'"
   },
   "dependencies": {
-    "@aws-sdk/client-eventbridge": "^3.470.0",
+    "@aws-sdk/client-eventbridge": "^3.540.0",
     "@swarmion/serverless-helpers": "^0.31.3",
     "@types/aws-lambda": "^8.10.130",
     "@types/http-errors": "^2.0.4",

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/SQSContract.test.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/SQSContract.test.ts
@@ -1,0 +1,13 @@
+import {
+  messageAttributesSchema,
+  messageBodySchema,
+  sqsContract,
+} from './mock';
+
+describe('sqsContract tests', () => {
+  it('should be properly initialized', () => {
+    expect(sqsContract.id).toBe('myAwesomeSQSContract');
+    expect(sqsContract.messageBodySchema).toEqual(messageBodySchema);
+    expect(sqsContract.messageAttributesSchema).toBe(messageAttributesSchema);
+  });
+});

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/basicLambdaHandler.test.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/basicLambdaHandler.test.ts
@@ -1,9 +1,9 @@
 import Ajv from 'ajv';
 
 import { getHandlerContextMock } from '__mocks__/requestContext';
+import { getHandler } from 'features/lambdaHandler';
 
 import { baseRecord, minimalSqsContract, sqsContract } from './mock';
-import { getLambdaSQSHandler } from '../features';
 
 const ajv = new Ajv({ keywords: ['faker'] });
 
@@ -11,7 +11,10 @@ describe('SQSContract basic handler test', () => {
   const fakeContext = getHandlerContextMock();
 
   it('should handle the records', async () => {
-    const handler = getLambdaSQSHandler(sqsContract, { ajv })(async event => {
+    const handler = getHandler(sqsContract, {
+      ajv,
+      handleBatchedRecords: false,
+    })(async event => {
       await Promise.resolve();
 
       return event.records.map(record => ({
@@ -49,7 +52,10 @@ describe('SQSContract basic handler test', () => {
   });
 
   it('should throw if the body of the record is invalid', async () => {
-    const handler = getLambdaSQSHandler(sqsContract, { ajv })(async event => {
+    const handler = getHandler(sqsContract, {
+      ajv,
+      handleBatchedRecords: false,
+    })(async event => {
       await Promise.resolve();
 
       return event.records[0]!.body.toto;
@@ -69,7 +75,10 @@ describe('SQSContract basic handler test', () => {
   });
 
   it('should throw if one of the message attribute of the record is invalid', async () => {
-    const handler = getLambdaSQSHandler(sqsContract, { ajv })(async event => {
+    const handler = getHandler(sqsContract, {
+      ajv,
+      handleBatchedRecords: false,
+    })(async event => {
       await Promise.resolve();
 
       return event.records[0]!.body.toto;
@@ -95,9 +104,10 @@ describe('SQSContract basic handler test', () => {
   });
 
   it('should not throw it the payload is invalid but validation is disabled in options', async () => {
-    const handler = getLambdaSQSHandler(sqsContract, {
+    const handler = getHandler(sqsContract, {
       ajv,
       validateBody: false,
+      handleBatchedRecords: false,
     })(async event => {
       await Promise.resolve();
 
@@ -124,7 +134,10 @@ describe('SQSContract basic handler test', () => {
 
     const sideEffects = { mySideEffect: mockSideEffect };
 
-    const handler = getLambdaSQSHandler(sqsContract, { ajv })(async (
+    const handler = getHandler(sqsContract, {
+      ajv,
+      handleBatchedRecords: false,
+    })(async (
       event,
       _context,
       _callback,
@@ -151,9 +164,10 @@ describe('SQSContract basic handler test', () => {
   });
 
   it('should not JSON parse the body if bodyParser is undefined', async () => {
-    const handler = getLambdaSQSHandler(minimalSqsContract, {
+    const handler = getHandler(minimalSqsContract, {
       ajv,
       bodyParser: undefined,
+      handleBatchedRecords: false,
     })(async event => {
       await Promise.resolve();
 
@@ -170,9 +184,10 @@ describe('SQSContract basic handler test', () => {
     expect(result).toEqual('myBody');
   });
   it('should parse the body with the custom bodyParser if provided', async () => {
-    const handler = getLambdaSQSHandler(minimalSqsContract, {
+    const handler = getHandler(minimalSqsContract, {
       ajv,
       bodyParser: (body: string) => `${body}-parsed`,
+      handleBatchedRecords: false,
     })(async event => {
       await Promise.resolve();
 

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/basicLambdaHandler.test.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/basicLambdaHandler.test.ts
@@ -1,0 +1,191 @@
+import Ajv from 'ajv';
+
+import { getHandlerContextMock } from '__mocks__/requestContext';
+
+import { baseRecord, minimalSqsContract, sqsContract } from './mock';
+import { getLambdaSQSHandler } from '../features';
+
+const ajv = new Ajv({ keywords: ['faker'] });
+
+describe('SQSContract basic handler test', () => {
+  const fakeContext = getHandlerContextMock();
+
+  it('should handle the records', async () => {
+    const handler = getLambdaSQSHandler(sqsContract, { ajv })(async event => {
+      await Promise.resolve();
+
+      return event.records.map(record => ({
+        bodyToto: record.body.toto,
+        messageAttributesTata: record.messageAttributes.tata,
+      }));
+    });
+
+    const result = await handler(
+      {
+        Records: [
+          { ...baseRecord, body: JSON.stringify({ toto: 'totoValue1' }) },
+          {
+            ...baseRecord,
+            body: JSON.stringify({ toto: 'totoValue2' }),
+            messageAttributes: {
+              tata: { stringValue: 'tataValue', dataType: 'String' },
+            },
+          },
+        ],
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toEqual([
+      {
+        bodyToto: 'totoValue1',
+        messageAttributesTata: undefined,
+      },
+      {
+        bodyToto: 'totoValue2',
+        messageAttributesTata: 'tataValue',
+      },
+    ]);
+  });
+
+  it('should throw if the body of the record is invalid', async () => {
+    const handler = getLambdaSQSHandler(sqsContract, { ajv })(async event => {
+      await Promise.resolve();
+
+      return event.records[0]!.body.toto;
+    });
+
+    await expect(
+      handler(
+        {
+          Records: [
+            { ...baseRecord, body: JSON.stringify({ tata: 'totoValue1' }) },
+          ],
+        },
+        fakeContext,
+        () => null,
+      ),
+    ).rejects.toThrowError();
+  });
+
+  it('should throw if one of the message attribute of the record is invalid', async () => {
+    const handler = getLambdaSQSHandler(sqsContract, { ajv })(async event => {
+      await Promise.resolve();
+
+      return event.records[0]!.body.toto;
+    });
+
+    await expect(
+      handler(
+        {
+          Records: [
+            {
+              ...baseRecord,
+              body: JSON.stringify({ toto: 'totoValue1' }),
+              messageAttributes: {
+                titi: { stringValue: 'titiValue', dataType: 'String' },
+              },
+            },
+          ],
+        },
+        fakeContext,
+        () => null,
+      ),
+    ).rejects.toThrowError();
+  });
+
+  it('should not throw it the payload is invalid but validation is disabled in options', async () => {
+    const handler = getLambdaSQSHandler(sqsContract, {
+      ajv,
+      validateBody: false,
+    })(async event => {
+      await Promise.resolve();
+
+      return event.records[0]!.body;
+    });
+
+    const result = await handler(
+      {
+        Records: [
+          { ...baseRecord, body: JSON.stringify({ tata: 'totoValue1' }) },
+        ],
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toEqual({ tata: 'totoValue1' });
+  });
+
+  it('should accept additional arguments', async () => {
+    const mockSideEffect = vitest.fn(() => 'tata');
+    interface SideEffects {
+      mySideEffect: () => string;
+    }
+
+    const sideEffects = { mySideEffect: mockSideEffect };
+
+    const handler = getLambdaSQSHandler(sqsContract, { ajv })(async (
+      event,
+      _context,
+      _callback,
+      { mySideEffect }: SideEffects = sideEffects,
+    ) => {
+      await Promise.resolve();
+
+      const sideEffectRes = mySideEffect();
+
+      return `${event.records[0]!.body.toto}-${sideEffectRes}`;
+    });
+
+    const result = await handler(
+      {
+        Records: [
+          { ...baseRecord, body: JSON.stringify({ toto: 'totoValue1' }) },
+        ],
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toBe('totoValue1-tata');
+    expect(mockSideEffect).toHaveBeenCalledOnce();
+  });
+
+  it('should not JSON parse the body if bodyParser is undefined', async () => {
+    const handler = getLambdaSQSHandler(minimalSqsContract, {
+      ajv,
+      bodyParser: undefined,
+    })(async event => {
+      await Promise.resolve();
+
+      return event.records[0]!.body;
+    });
+
+    const result = await handler(
+      {
+        Records: [{ ...baseRecord, body: 'myBody' }],
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toEqual('myBody');
+  });
+  it('should parse the body with the custom bodyParser if provided', async () => {
+    const handler = getLambdaSQSHandler(minimalSqsContract, {
+      ajv,
+      bodyParser: (body: string) => `${body}-parsed`,
+    })(async event => {
+      await Promise.resolve();
+
+      return event.records[0]!.body;
+    });
+
+    const result = await handler(
+      {
+        Records: [{ ...baseRecord, body: 'myBody' }],
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toEqual('myBody-parsed');
+  });
+});

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/fullContractSchema.test.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/fullContractSchema.test.ts
@@ -1,0 +1,37 @@
+import {
+  messageAttributesSchema,
+  messageBodySchema,
+  minimalSqsContract,
+  sqsContract,
+} from './mock';
+import { getFullContractSchema } from '../features';
+
+describe('SQS contract fullContract tests', () => {
+  it('should generate a proper full Contract with minimal config', () => {
+    const fullContractSchema = getFullContractSchema(minimalSqsContract);
+    expect(fullContractSchema).toEqual({
+      type: 'object',
+      properties: {
+        id: { const: 'myAwesomeMinimalSQSContract' },
+        contractType: { const: 'SQS' },
+        messageBodySchema: { type: 'string' },
+      },
+      required: ['id', 'contractType', 'messageBodySchema'],
+      additionalProperties: false,
+    });
+  });
+  it('should generate a proper full Contract with full config', () => {
+    const fullContractSchema = getFullContractSchema(sqsContract);
+    expect(fullContractSchema).toEqual({
+      type: 'object',
+      properties: {
+        id: { const: 'myAwesomeSQSContract' },
+        contractType: { const: 'SQS' },
+        messageBodySchema,
+        messageAttributesSchema,
+      },
+      required: ['id', 'contractType', 'messageBodySchema'],
+      additionalProperties: false,
+    });
+  });
+});

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/fullContractSchema.type.test.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/fullContractSchema.type.test.ts
@@ -1,0 +1,12 @@
+import { JSONSchema } from 'json-schema-to-ts';
+
+import { sqsContract } from './mock';
+import { FullContractSchemaType } from '../types';
+
+type Check =
+  FullContractSchemaType<typeof sqsContract> extends JSONSchema
+    ? 'pass'
+    : 'fail';
+
+const check: Check = 'pass';
+check;

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/lambdaHandler.test.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/lambdaHandler.test.ts
@@ -1,0 +1,190 @@
+import Ajv from 'ajv';
+
+import { getHandlerContextMock } from '__mocks__/requestContext';
+import { getHandler } from 'features/lambdaHandler';
+
+import { baseRecord, minimalSqsContract, sqsContract } from './mock';
+
+const ajv = new Ajv({ keywords: ['faker'] });
+
+describe('SQSContract handler test', () => {
+  const fakeContext = getHandlerContextMock();
+
+  it('should handle the records', async () => {
+    const handler = getHandler(sqsContract, { ajv })(async event => {
+      await Promise.resolve();
+
+      return event.Records.map(record => ({
+        bodyToto: record.body.toto,
+        messageAttributesTata: record.messageAttributes.tata,
+      }));
+    });
+
+    const result = await handler(
+      {
+        Records: [
+          { ...baseRecord, body: JSON.stringify({ toto: 'totoValue1' }) },
+          {
+            ...baseRecord,
+            body: JSON.stringify({ toto: 'totoValue2' }),
+            messageAttributes: {
+              tata: { stringValue: 'tataValue', dataType: 'String' },
+            },
+          },
+        ],
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toEqual([
+      {
+        bodyToto: 'totoValue1',
+        messageAttributesTata: undefined,
+      },
+      {
+        bodyToto: 'totoValue2',
+        messageAttributesTata: 'tataValue',
+      },
+    ]);
+  });
+
+  it('should throw if the body of the record is invalid', async () => {
+    const handler = getHandler(sqsContract, { ajv })(async event => {
+      await Promise.resolve();
+
+      return event.Records[0]!.body.toto;
+    });
+
+    await expect(
+      handler(
+        {
+          Records: [
+            { ...baseRecord, body: JSON.stringify({ tata: 'totoValue1' }) },
+          ],
+        },
+        fakeContext,
+        () => null,
+      ),
+    ).rejects.toThrowError();
+  });
+
+  it('should throw if one of the message attribute of the record is invalid', async () => {
+    const handler = getHandler(sqsContract, { ajv })(async event => {
+      await Promise.resolve();
+
+      return event.Records[0]!.body.toto;
+    });
+
+    await expect(
+      handler(
+        {
+          Records: [
+            {
+              ...baseRecord,
+              body: JSON.stringify({ toto: 'totoValue1' }),
+              messageAttributes: {
+                titi: { stringValue: 'titiValue', dataType: 'String' },
+              },
+            },
+          ],
+        },
+        fakeContext,
+        () => null,
+      ),
+    ).rejects.toThrowError();
+  });
+
+  it('should not throw it the payload is invalid but validation is disabled in options', async () => {
+    const handler = getHandler(sqsContract, { ajv, validateBody: false })(
+      async event => {
+        await Promise.resolve();
+
+        return event.Records[0]!.body;
+      },
+    );
+
+    const result = await handler(
+      {
+        Records: [
+          { ...baseRecord, body: JSON.stringify({ tata: 'totoValue1' }) },
+        ],
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toEqual({ tata: 'totoValue1' });
+  });
+
+  it('should accept additional arguments', async () => {
+    const mockSideEffect = vitest.fn(() => 'tata');
+    interface SideEffects {
+      mySideEffect: () => string;
+    }
+
+    const sideEffects = { mySideEffect: mockSideEffect };
+
+    const handler = getHandler(sqsContract, { ajv })(async (
+      event,
+      _context,
+      _callback,
+      { mySideEffect }: SideEffects = sideEffects,
+    ) => {
+      await Promise.resolve();
+
+      const sideEffectRes = mySideEffect();
+
+      return `${event.Records[0]!.body.toto}-${sideEffectRes}`;
+    });
+
+    const result = await handler(
+      {
+        Records: [
+          { ...baseRecord, body: JSON.stringify({ toto: 'totoValue1' }) },
+        ],
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toBe('totoValue1-tata');
+    expect(mockSideEffect).toHaveBeenCalledOnce();
+  });
+
+  it('should not JSON parse the body if bodyParser is undefined', async () => {
+    const handler = getHandler(minimalSqsContract, {
+      ajv,
+      bodyParser: undefined,
+    })(async event => {
+      await Promise.resolve();
+
+      return event.Records[0]!.body;
+    });
+
+    const result = await handler(
+      {
+        Records: [{ ...baseRecord, body: 'myBody' }],
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toEqual('myBody');
+  });
+  it('should parse the body with the custom bodyParser if provided', async () => {
+    const handler = getHandler(minimalSqsContract, {
+      ajv,
+      bodyParser: (body: string) => `${body}-parsed`,
+    })(async event => {
+      await Promise.resolve();
+
+      return event.Records[0]!.body;
+    });
+
+    const result = await handler(
+      {
+        Records: [{ ...baseRecord, body: 'myBody' }],
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toEqual('myBody-parsed');
+  });
+});

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/mock.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/mock.ts
@@ -31,3 +31,25 @@ export const minimalSqsContract = new SQSContract({
     type: 'string',
   },
 });
+
+export const baseRecord = {
+  messageId: '94187476-d900-4885-9db1-0146dea271df',
+  receiptHandle:
+    'AQEBIG00N51r0pdueidoj1AYCpxO3iKsIKNsf1wVIrwcdCDfs9UUxP8NUgPMsk8oAjyohJ+IYCYoFo4KOc7xwBhI1VNbBDHwek32JQbxmxGNHiG4U15UQ5pdtx70DTEVbqHPma3vdSvJ+MX3/oD3EcCCcmfSarFNBkDvsxTOJM6mMqVeZyfPnB4haX6y6y9r8i4m3LjqdWpVW4O5u0eKVjaSM8EC9pPf4jpezjxQnQDYl8BiD0ENU3aJORtPKKqOc7Nw0uDCGcZwQHnzCQagrh+fcu16NipNHiCoyEJfvQNrlqw=',
+  body: '{}',
+  attributes: {
+    ApproximateReceiveCount: '1',
+    SentTimestamp: '1654255344046',
+    SequenceNumber: '18870233441785327616',
+    MessageGroupId: 'my-group-id',
+    SenderId: 'AIDAY5TJ4WEAN6SB57RST',
+    MessageDeduplicationId:
+      '887e7257601af74096f169d27fe8d16d9fbc147989e4d9f63c9dc4c533b3dd10',
+    ApproximateFirstReceiveTimestamp: '1654255404104',
+  },
+  messageAttributes: {},
+  md5OfBody: '8a34a7d0f20ae875018098c3280e947a',
+  eventSource: 'aws:sqs',
+  eventSourceARN: 'arn:aws:sqs:eu-west-1:xxxx:my-queue',
+  awsRegion: 'eu-west-1',
+};

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/mock.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/mock.ts
@@ -1,0 +1,33 @@
+import { JSONSchema } from 'json-schema-to-ts';
+
+import { SQSContract } from '../sqsContract';
+
+export const messageBodySchema = {
+  type: 'object',
+  properties: {
+    toto: { type: 'string' },
+  },
+  required: ['toto'],
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+export const messageAttributesSchema = {
+  type: 'object',
+  properties: {
+    tata: { type: 'string' },
+  },
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+export const sqsContract = new SQSContract({
+  id: 'myAwesomeSQSContract',
+  messageBodySchema,
+  messageAttributesSchema,
+});
+
+export const minimalSqsContract = new SQSContract({
+  id: 'myAwesomeMinimalSQSContract',
+  messageBodySchema: {
+    type: 'string',
+  },
+});

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/sendMessage.test.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/sendMessage.test.ts
@@ -12,13 +12,13 @@ const sqsClient = new SQSClient({});
 const queueUrl = 'mySqsUrl';
 
 const sqsClientMock = mockClient(SQSClient);
-sqsClientMock.on(SendMessageCommand).resolves({});
 
 describe('SQS contract sendMessage tests', () => {
   beforeEach(() => {
     sqsClientMock.reset();
+    sqsClientMock.on(SendMessageCommand).resolves({});
   });
-  it('should call SQS with the correct parameters', async () => {
+  it('calls SQS with the correct parameters', async () => {
     const mySendMessage = buildSendMessage(sqsContract, {
       queueUrl,
       sqsClient,
@@ -40,5 +40,20 @@ describe('SQS contract sendMessage tests', () => {
         },
       },
     });
+  });
+  it('throws if the message is invalid', async () => {
+    const mySendMessage = buildSendMessage(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+    });
+
+    await expect(
+      mySendMessage({
+        // @ts-expect-error - this is the point of the test
+        body: { tata: 'totoValue' },
+        messageAttributes: { tata: 'tataValue' },
+      }),
+    ).rejects.toThrow();
   });
 });

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/sendMessage.test.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/sendMessage.test.ts
@@ -1,0 +1,44 @@
+import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+import Ajv from 'ajv';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach } from 'vitest';
+
+import { sqsContract } from './mock';
+import { buildSendMessage } from '../features';
+
+const ajv = new Ajv({ keywords: ['faker'] });
+
+const sqsClient = new SQSClient({});
+const queueUrl = 'mySqsUrl';
+
+const sqsClientMock = mockClient(SQSClient);
+sqsClientMock.on(SendMessageCommand).resolves({});
+
+describe('SQS contract sendMessage tests', () => {
+  beforeEach(() => {
+    sqsClientMock.reset();
+  });
+  it('should call SQS with the correct parameters', async () => {
+    const mySendMessage = buildSendMessage(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+    });
+
+    await mySendMessage({
+      body: { toto: 'totoValue' },
+      messageAttributes: { tata: 'tataValue' },
+    });
+
+    expect(sqsClientMock.call(0).args[0].input).toEqual({
+      QueueUrl: 'mySqsUrl',
+      MessageBody: '{"toto":"totoValue"}',
+      MessageAttributes: {
+        tata: {
+          DataType: 'String',
+          StringValue: 'tataValue',
+        },
+      },
+    });
+  });
+});

--- a/packages/serverless-contracts/src/contracts/SQS/__tests__/sendMessages.test.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/__tests__/sendMessages.test.ts
@@ -1,0 +1,295 @@
+import { SendMessageBatchCommand, SQSClient } from '@aws-sdk/client-sqs';
+import Ajv from 'ajv';
+import { mockClient } from 'aws-sdk-client-mock';
+import { randomBytes } from 'crypto';
+import { beforeEach, expect } from 'vitest';
+
+import { sqsContract } from './mock';
+import { buildSendMessages } from '../features';
+
+const ajv = new Ajv({ keywords: ['faker'] });
+
+const sqsClientMock = mockClient(SQSClient);
+const sqsClient = new SQSClient({});
+
+const queueUrl = 'mySqsUrl';
+
+// Not sure why the length is divided by 2
+// But empirically it works: Buffer.byteLength(generateRandomText(N), 'utf8') = N
+const generateRandomText = (length: number): string =>
+  randomBytes(length / 2).toString('hex');
+
+const createMessages = ({
+  length,
+  offset = 0,
+}: {
+  length: number;
+  offset?: number;
+}) =>
+  Array.from({ length }).map((_, index) => ({
+    Id: `id${offset + index}`,
+    body: { toto: `totoValue${offset + index}` },
+  }));
+
+describe('SQS contract sendMessages tests', () => {
+  beforeEach(() => {
+    sqsClientMock.reset();
+    sqsClientMock.on(SendMessageBatchCommand).resolves({ Failed: [] });
+  });
+  it('serializes the messages', async () => {
+    const mySendMessages = buildSendMessages(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+    });
+
+    await mySendMessages([
+      {
+        body: { toto: 'totoValue1' },
+        messageAttributes: { tata: 'tataValue1' },
+      },
+      {
+        body: { toto: 'totoValue2' },
+        messageAttributes: { tata: 'tataValue2' },
+      },
+    ]);
+
+    const calls = sqsClientMock.commandCalls(SendMessageBatchCommand);
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.args[0].input.Entries).toEqual([
+      {
+        Id: expect.any(String) as string,
+        MessageAttributes: {
+          tata: {
+            DataType: 'String',
+            StringValue: 'tataValue1',
+          },
+        },
+        MessageBody: '{"toto":"totoValue1"}',
+      },
+      {
+        Id: expect.any(String) as string,
+        MessageAttributes: {
+          tata: {
+            DataType: 'String',
+            StringValue: 'tataValue2',
+          },
+        },
+        MessageBody: '{"toto":"totoValue2"}',
+      },
+    ]);
+  });
+  it('throws if one of the messages is invalid', async () => {
+    const mySendMessages = buildSendMessages(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+    });
+
+    await expect(
+      mySendMessages([
+        {
+          body: { toto: 'totoValue1' },
+          messageAttributes: { tata: 'tataValue1' },
+        },
+        {
+          // @ts-expect-error - this is the point of the test
+          body: { tata: 'totoValue2' },
+          messageAttributes: { tata: 'tataValue2' },
+        },
+      ]),
+    ).rejects.toThrow();
+  });
+  it('calls SQS with batches of 10 messages', async () => {
+    const mySendMessages = buildSendMessages(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+    });
+
+    await mySendMessages(createMessages({ length: 20 }));
+
+    const calls = sqsClientMock.commandCalls(SendMessageBatchCommand);
+    expect(calls.length).toBe(2);
+    expect(calls[0]!.args[0].input.Entries!.length).toBe(10);
+    expect(calls[1]!.args[0].input.Entries!.length).toBe(10);
+  });
+  it('calls SQS with more batches if some messages are too big', async () => {
+    const mySendMessages = buildSendMessages(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+    });
+    await mySendMessages([
+      {
+        body: { toto: generateRandomText(256 * 1000 - 100) }, // 256Kb - 100b: the first message must be close to the limit to avoid other messages to be batched with it
+      },
+      ...createMessages({ length: 19, offset: 1 }),
+    ]);
+
+    const calls = sqsClientMock.commandCalls(SendMessageBatchCommand);
+    expect(calls.length).toBe(3);
+    expect(calls[0]!.args[0].input.Entries!.length).toBe(1);
+    expect(calls[1]!.args[0].input.Entries!.length).toBe(10);
+    expect(calls[2]!.args[0].input.Entries!.length).toBe(9);
+  });
+  it('calls SQS with more batches if some messages are too big 2', async () => {
+    const mySendMessages = buildSendMessages(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+    });
+    await mySendMessages([
+      {
+        body: { toto: generateRandomText(256 * 1000 - 350) }, // 256Kb - 350b: Let other messages be batched with it
+      },
+      ...createMessages({ length: 19, offset: 1 }),
+    ]);
+
+    const calls = sqsClientMock.commandCalls(SendMessageBatchCommand);
+    expect(calls.length).toBe(3);
+    expect(calls[0]!.args[0].input.Entries!.length).toBe(6);
+    expect(calls[1]!.args[0].input.Entries!.length).toBe(10);
+    expect(calls[2]!.args[0].input.Entries!.length).toBe(4);
+  });
+  it('throws if one of the messages is too big', async () => {
+    const mySendMessages = buildSendMessages(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+    });
+
+    await expect(
+      mySendMessages([
+        {
+          body: { toto: generateRandomText(256 * 1024) }, // 256Kb + the size of the envelope > 256kb
+        },
+        {
+          body: { toto: 'totoValue2' },
+        },
+      ]),
+    ).rejects.toThrow();
+  });
+  it('retries the failed messages', async () => {
+    sqsClientMock
+      .on(SendMessageBatchCommand)
+      .resolvesOnce({
+        Failed: [
+          { Id: 'id0', SenderFault: undefined, Code: undefined },
+          { Id: 'id2', SenderFault: undefined, Code: undefined },
+          { Id: 'id3', SenderFault: undefined, Code: undefined },
+          { Id: 'id5', SenderFault: undefined, Code: undefined },
+          { Id: 'id9', SenderFault: undefined, Code: undefined },
+        ],
+      })
+      .resolvesOnce({
+        Failed: [
+          { Id: 'id3', SenderFault: undefined, Code: undefined },
+          { Id: 'id9', SenderFault: undefined, Code: undefined },
+        ],
+      })
+      .resolvesOnce({
+        Failed: [],
+      });
+    const mySendMessages = buildSendMessages(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+    });
+
+    await mySendMessages(createMessages({ length: 10 }));
+
+    const calls = sqsClientMock.commandCalls(SendMessageBatchCommand);
+    expect(calls.length).toBe(3);
+    expect(calls[0]!.args[0].input.Entries!.length).toBe(10);
+    expect(calls[1]!.args[0].input.Entries!.length).toBe(5);
+    expect(calls[2]!.args[0].input.Entries!.length).toBe(2);
+  });
+  it('throws by default if it fails to send some message to the SQS', async () => {
+    sqsClientMock
+      .on(SendMessageBatchCommand)
+      .resolvesOnce({
+        Failed: [
+          { Id: 'id0', SenderFault: undefined, Code: undefined },
+          { Id: 'id2', SenderFault: undefined, Code: undefined },
+          { Id: 'id3', SenderFault: undefined, Code: undefined },
+          { Id: 'id5', SenderFault: undefined, Code: undefined },
+          { Id: 'id9', SenderFault: undefined, Code: undefined },
+        ],
+      })
+      .resolvesOnce({
+        Failed: [
+          { Id: 'id3', SenderFault: undefined, Code: undefined },
+          { Id: 'id9', SenderFault: undefined, Code: undefined },
+        ],
+      })
+      .resolves({
+        Failed: [{ Id: 'id9', SenderFault: undefined, Code: undefined }],
+      });
+    const mySendMessages = buildSendMessages(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+    });
+
+    await expect(
+      mySendMessages(createMessages({ length: 10 })),
+    ).rejects.toThrow();
+
+    const calls = sqsClientMock.commandCalls(SendMessageBatchCommand);
+    expect(calls.length).toBe(3);
+    expect(calls[0]!.args[0].input.Entries!.length).toBe(10);
+    expect(calls[1]!.args[0].input.Entries!.length).toBe(5);
+    expect(calls[2]!.args[0].input.Entries!.length).toBe(2);
+  });
+  it('adapts the retry behaviour to the configuration', async () => {
+    sqsClientMock
+      .on(SendMessageBatchCommand)
+      .resolvesOnce({
+        Failed: [
+          { Id: 'id0', SenderFault: undefined, Code: undefined },
+          { Id: 'id2', SenderFault: undefined, Code: undefined },
+          { Id: 'id3', SenderFault: undefined, Code: undefined },
+          { Id: 'id5', SenderFault: undefined, Code: undefined },
+          { Id: 'id9', SenderFault: undefined, Code: undefined },
+        ],
+      })
+      .resolvesOnce({
+        Failed: [
+          { Id: 'id3', SenderFault: undefined, Code: undefined },
+          { Id: 'id9', SenderFault: undefined, Code: undefined },
+        ],
+      })
+      .resolves({
+        Failed: [{ Id: 'id9', SenderFault: undefined, Code: undefined }],
+      });
+    const mySendMessages = buildSendMessages(sqsContract, {
+      queueUrl,
+      sqsClient,
+      ajv,
+      throwOnFailedBatch: false,
+      maxRetries: 5,
+      baseDelay: 1,
+    });
+
+    const { failedItems } = await mySendMessages(
+      createMessages({ length: 10 }),
+    );
+
+    expect(failedItems).toEqual([
+      {
+        Code: undefined,
+        Id: 'id9',
+        SenderFault: undefined,
+      },
+    ]);
+
+    const calls = sqsClientMock.commandCalls(SendMessageBatchCommand);
+    expect(calls.length).toBe(5);
+    expect(calls[0]!.args[0].input.Entries!.length).toBe(10);
+    expect(calls[1]!.args[0].input.Entries!.length).toBe(5);
+    expect(calls[2]!.args[0].input.Entries!.length).toBe(2);
+    expect(calls[3]!.args[0].input.Entries!.length).toBe(1);
+    expect(calls[4]!.args[0].input.Entries!.length).toBe(1);
+  });
+});

--- a/packages/serverless-contracts/src/contracts/SQS/features/fullContractSchema.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/fullContractSchema.ts
@@ -1,0 +1,25 @@
+import { SQSContract } from '../sqsContract';
+import { FullContractSchemaType } from '../types/fullContract';
+
+/**
+ * Returns the aggregated SQSContract schema in order to compare contracts versions.
+ *
+ * This also enables to infer the type with `json-schema-to-ts`.
+ *
+ *  @param contract your EventBridgeContract
+ */
+export const getFullContractSchema = <Contract extends SQSContract>(
+  contract: Contract,
+): FullContractSchemaType<Contract> => ({
+  type: 'object',
+  properties: {
+    id: { const: contract.id },
+    contractType: { const: contract.contractType },
+    messageBodySchema: contract.messageBodySchema,
+    ...(Object.keys(contract.messageAttributesSchema).length > 0
+      ? { messageAttributesSchema: contract.messageAttributesSchema }
+      : {}),
+  },
+  required: ['id', 'contractType', 'messageBodySchema'],
+  additionalProperties: false,
+});

--- a/packages/serverless-contracts/src/contracts/SQS/features/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/index.ts
@@ -1,0 +1,1 @@
+export * from './fullContractSchema';

--- a/packages/serverless-contracts/src/contracts/SQS/features/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/index.ts
@@ -1,3 +1,4 @@
 export * from './fullContractSchema';
 export * from './lambdaHandler';
 export * from './sendMessage';
+export * from './sendMessages';

--- a/packages/serverless-contracts/src/contracts/SQS/features/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/index.ts
@@ -1,1 +1,2 @@
 export * from './fullContractSchema';
+export * from './lambdaHandler';

--- a/packages/serverless-contracts/src/contracts/SQS/features/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/index.ts
@@ -1,2 +1,3 @@
 export * from './fullContractSchema';
 export * from './lambdaHandler';
+export * from './sendMessage';

--- a/packages/serverless-contracts/src/contracts/SQS/features/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/lambdaHandler.ts
@@ -1,0 +1,63 @@
+import { SQSContract } from '../sqsContract';
+import {
+  DefaultGetSQSHandlerOptions,
+  GetSQSHandlerOptions,
+  SQSHandler,
+  SqsMessageAttributesType,
+  SqsMessageBodyType,
+  SwarmionSQSHandler,
+} from '../types';
+import { getRecordsValidator, parseRecord } from '../utils';
+
+const defaultOptions: DefaultGetSQSHandlerOptions = {
+  bodyParser: (body: string) => JSON.parse(body) as unknown,
+  validateBody: true,
+  validateAttributes: true,
+};
+
+export const getSQSHandler =
+  <
+    Contract extends SQSContract,
+    MessageBody = SqsMessageBodyType<Contract>,
+    MessageAttributes = SqsMessageAttributesType<Contract>,
+  >(
+    contract: Contract,
+    options: GetSQSHandlerOptions,
+  ) =>
+  <AdditionalArgs extends unknown[] = []>(
+    handler: SwarmionSQSHandler<MessageBody, MessageAttributes, AdditionalArgs>,
+  ): SQSHandler<AdditionalArgs> => {
+    const internalOptions = {
+      ...defaultOptions,
+      ...options,
+    };
+
+    const recordsValidator = getRecordsValidator(contract, internalOptions);
+
+    return async (
+      event,
+      context,
+      callback,
+      ...additionalArgs: AdditionalArgs
+    ) => {
+      const { Records } = event;
+
+      const parsedRecords = Records.map(
+        parseRecord<MessageBody, MessageAttributes>(internalOptions),
+      );
+      if (recordsValidator !== undefined) {
+        if (!recordsValidator(parsedRecords)) {
+          console.error('Error: Invalid records');
+          console.error(JSON.stringify(recordsValidator.errors, null, 2));
+          throw new Error('Invalid records');
+        }
+      }
+
+      return handler(
+        { Records: parsedRecords },
+        context,
+        callback,
+        ...additionalArgs,
+      );
+    };
+  };

--- a/packages/serverless-contracts/src/contracts/SQS/features/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/lambdaHandler.ts
@@ -53,12 +53,10 @@ const getGetSQSHandler =
       const parsedRecords = Records.map(
         parseRecord<MessageBody, MessageAttributes>(internalOptions),
       );
-      if (recordsValidator !== undefined) {
-        if (!recordsValidator(parsedRecords)) {
-          console.error('Error: Invalid records');
-          console.error(JSON.stringify(recordsValidator.errors, null, 2));
-          throw new Error('Invalid records');
-        }
+      if (recordsValidator !== undefined && !recordsValidator(parsedRecords)) {
+        console.error('Error: Invalid records');
+        console.error(JSON.stringify(recordsValidator.errors, null, 2));
+        throw new Error('Invalid records');
       }
 
       if (handleRecords === false) {

--- a/packages/serverless-contracts/src/contracts/SQS/features/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/lambdaHandler.ts
@@ -5,9 +5,14 @@ import {
   SQSHandler,
   SqsMessageAttributesType,
   SqsMessageBodyType,
+  SwarmionLambdaSQSHandler,
   SwarmionSQSHandler,
 } from '../types';
-import { getRecordsValidator, parseRecord } from '../utils';
+import {
+  getAllRecordsHandler,
+  getRecordsValidator,
+  parseRecord,
+} from '../utils';
 
 const defaultOptions: DefaultGetSQSHandlerOptions = {
   bodyParser: (body: string) => JSON.parse(body) as unknown,
@@ -15,7 +20,8 @@ const defaultOptions: DefaultGetSQSHandlerOptions = {
   validateAttributes: true,
 };
 
-export const getSQSHandler =
+const getGetSQSHandler =
+  <HandleRecords extends boolean = false>(handleRecords: HandleRecords) =>
   <
     Contract extends SQSContract,
     MessageBody = SqsMessageBodyType<Contract>,
@@ -25,7 +31,9 @@ export const getSQSHandler =
     options: GetSQSHandlerOptions,
   ) =>
   <AdditionalArgs extends unknown[] = []>(
-    handler: SwarmionSQSHandler<MessageBody, MessageAttributes, AdditionalArgs>,
+    handler: HandleRecords extends false
+      ? SwarmionLambdaSQSHandler<MessageBody, MessageAttributes, AdditionalArgs>
+      : SwarmionSQSHandler<MessageBody, MessageAttributes, AdditionalArgs>,
   ): SQSHandler<AdditionalArgs> => {
     const internalOptions = {
       ...defaultOptions,
@@ -53,11 +61,51 @@ export const getSQSHandler =
         }
       }
 
-      return handler(
-        { Records: parsedRecords },
+      if (handleRecords === false) {
+        return (
+          handler as SwarmionLambdaSQSHandler<
+            MessageBody,
+            MessageAttributes,
+            AdditionalArgs
+          >
+        )({ records: parsedRecords }, context, callback, ...additionalArgs);
+      }
+
+      const allRecordsHandler = getAllRecordsHandler(
+        // handleRecords is true, handler is SwarmionSQSHandler. Typescript is not able to infer this
+        handler as SwarmionSQSHandler<
+          MessageBody,
+          MessageAttributes,
+          AdditionalArgs
+        >,
         context,
         callback,
-        ...additionalArgs,
+        additionalArgs,
       );
+
+      return allRecordsHandler({ records: parsedRecords });
     };
   };
+
+/**
+ * Returns the basic Swarmion handler for SQS,
+ * The wrapper parses the body of the SQS messages
+ * and calls the handler with all the records parsed and typed.
+ * It must process all the records and handle errors if necessary.
+ * Use getSQSHandler to avoid handling the whole batch, and to automatically process errors.
+ * The handler function can define additional arguments
+ */
+export const getLambdaSQSHandler = getGetSQSHandler(false);
+
+/**
+ * Returns the Swarmion handler for SQS.
+ * The wrapper parses the body of the SQS messages and report to SQS the batch failure.
+ * It calls the handle with only one record of the batch.
+ * The record is parsed and typed.
+ * It can throw an error if the record is invalid.
+ * The wrapper will catch it and inform the SQS that the record couldn't be processed
+ * following the batch failure reporting spec.
+ * https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+ * The handler function can define additional arguments
+ */
+export const getSQSHandler = getGetSQSHandler(true);

--- a/packages/serverless-contracts/src/contracts/SQS/features/sendMessage.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/sendMessage.ts
@@ -1,0 +1,84 @@
+import { SendMessageCommand } from '@aws-sdk/client-sqs';
+
+import { SQSContract } from '../sqsContract';
+import {
+  SendMessageBuilderOptions,
+  SendMessageSideEffect,
+  SqsMessage,
+} from '../types';
+import {
+  getBodyValidator,
+  getMessageAttributesValidator,
+  serializeMessageAttributes,
+} from '../utils';
+
+const defaultOptions = {
+  validateMessage: true,
+  bodySerializer: JSON.stringify,
+} satisfies Partial<SendMessageBuilderOptions<SQSContract>>;
+
+const validateMessage = <Contract extends SQSContract>({
+  contract,
+  message,
+  options,
+}: {
+  contract: Contract;
+  message: SqsMessage<Contract>;
+  options: SendMessageBuilderOptions<Contract>;
+}) => {
+  const { body, messageAttributes } = message;
+
+  const bodyValidator = getBodyValidator<Contract>(contract, options);
+  if (bodyValidator !== undefined && !bodyValidator(body)) {
+    console.error('Error: Invalid message body');
+    console.error(JSON.stringify(bodyValidator.errors, null, 2));
+    throw new Error('Error: Invalid message body');
+  }
+
+  const messageAttributesValidator = getMessageAttributesValidator<Contract>(
+    contract,
+    options,
+  );
+  if (
+    messageAttributesValidator !== undefined &&
+    !messageAttributesValidator(messageAttributes)
+  ) {
+    console.error('Error: Invalid message attributes');
+    console.error(JSON.stringify(messageAttributesValidator.errors, null, 2));
+    throw new Error('Error: Invalid message attributes');
+  }
+};
+
+export const buildSendMessage =
+  <Contract extends SQSContract>(
+    contract: Contract,
+    options: SendMessageBuilderOptions<Contract>,
+  ): SendMessageSideEffect<Contract> =>
+  async message => {
+    const internalOptions = {
+      ...defaultOptions,
+      ...options,
+    };
+    const { queueUrl, sqsClient, bodySerializer } = internalOptions;
+    const { body, messageAttributes, ...restMessage } = message;
+
+    validateMessage<Contract>({ contract, message, options: internalOptions });
+
+    const command = new SendMessageCommand({
+      MessageBody:
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- bodySerializer can be undefined if explicitly set to undefined in the options
+        bodySerializer !== undefined ? JSON.stringify(body) : (body as string),
+      QueueUrl: typeof queueUrl === 'string' ? queueUrl : queueUrl(),
+      ...(messageAttributes !== undefined && messageAttributes !== null
+        ? {
+            MessageAttributes: serializeMessageAttributes(
+              messageAttributes as Record<string, unknown>, // messageAttributes generic infered type has {} as type. I don't know why
+              contract,
+            ),
+          }
+        : {}),
+      ...restMessage,
+    });
+
+    await sqsClient.send(command);
+  };

--- a/packages/serverless-contracts/src/contracts/SQS/features/sendMessages.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/sendMessages.ts
@@ -1,0 +1,149 @@
+import {
+  SendMessageBatchCommand,
+  SendMessageBatchRequestEntry,
+} from '@aws-sdk/client-sqs';
+import { BatchResultErrorEntry } from '@aws-sdk/client-sqs/dist-types/models/models_0';
+
+import { SQSContract } from '../sqsContract';
+import { SendMessagesBuilderOptions, SendMessagesSideEffect } from '../types';
+import {
+  chunkSQSMessagesBatch,
+  getExponentialBackoffDelay,
+  serializeMessage,
+  validateMessages,
+  wait,
+} from '../utils';
+
+const defaultOptions = {
+  validateMessage: true,
+  bodySerializer: JSON.stringify,
+  maxRetries: 3,
+  baseDelay: 100,
+  throwOnFailedBatch: true,
+} satisfies Partial<SendMessagesBuilderOptions<SQSContract>>;
+
+const sendOneBatch = async <Contract extends SQSContract>(
+  batch: SendMessageBatchRequestEntry[],
+  options: Omit<
+    Required<SendMessagesBuilderOptions<Contract>>,
+    'ajv' | 'queueUrl'
+  > & { queueUrl: string },
+): Promise<{ failedItems: BatchResultErrorEntry[] }> => {
+  const { sqsClient, queueUrl, maxRetries, baseDelay } = options;
+
+  let unprocessedItems: SendMessageBatchRequestEntry[] = batch;
+  let attempts = 0;
+  let failedItems: BatchResultErrorEntry[] = [];
+
+  do {
+    const { Failed } = await sqsClient.send(
+      new SendMessageBatchCommand({
+        QueueUrl: queueUrl,
+        Entries: unprocessedItems,
+      }),
+    );
+    failedItems = Failed ?? [];
+
+    if (failedItems.length > 0) {
+      attempts++;
+      console.warn(
+        `Attempt ${attempts}: Failed to process ${failedItems.length} items. Retrying after delay...`,
+      );
+
+      const failedIds = failedItems.map(({ Id }) => Id);
+
+      // Retry only the failed items
+      unprocessedItems = unprocessedItems.filter(({ Id }) =>
+        failedIds.includes(Id),
+      );
+
+      // Delay before the next attempt - exponential backoff
+      if (attempts < maxRetries) {
+        const delayDuration = getExponentialBackoffDelay(
+          attempts - 1,
+          baseDelay,
+        );
+        console.info(`Delaying for ${delayDuration} ms...`);
+        await wait(delayDuration);
+      }
+    }
+  } while (failedItems.length > 0 && attempts < maxRetries);
+
+  return { failedItems };
+};
+
+const sendBatchedMessages = async <Contract extends SQSContract>({
+  messages,
+  options,
+}: {
+  messages: SendMessageBatchRequestEntry[];
+  options: Omit<Required<SendMessagesBuilderOptions<Contract>>, 'ajv'>;
+}): Promise<{ failedItems: BatchResultErrorEntry[] }> => {
+  const {
+    queueUrl: queueUrlOrGetter,
+    maxRetries,
+    throwOnFailedBatch,
+  } = options;
+  const queueUrl =
+    typeof queueUrlOrGetter === 'string'
+      ? queueUrlOrGetter
+      : queueUrlOrGetter();
+  const failedItems: BatchResultErrorEntry[] = [];
+
+  // Slice events into batches of 10 (max limit for SQS sendMessageBatch) and which size is less than 256KB
+  const batches = chunkSQSMessagesBatch(messages);
+
+  // do not parallelize this loop, as it will cause throttling for FIFO queues
+  for (const batch of batches) {
+    const { failedItems: batchFailedItems } = await sendOneBatch<Contract>(
+      batch,
+      {
+        ...options,
+        queueUrl,
+      },
+    );
+    failedItems.push(...batchFailedItems);
+  }
+
+  if (failedItems.length > 0 && throwOnFailedBatch) {
+    throw new Error(
+      `Failed to send ${failedItems.length} items to SQS after ${maxRetries} attempts`,
+    );
+  }
+
+  return { failedItems };
+};
+
+/**
+ * creates a sendMessages side effect
+ * The sendMessages function will send an array of messages to the SQS queue to the full extent of its capabilities:
+ * - It validates the messages against the contract
+ * - It chunks the array of messages into batches
+ * - It retries with exponential backoff the elements of the batches that failed to be sent (if AWS throttles the requests for examples)
+ * - By default, it throws an error if one of the message cannot be sent. You can also configure it to return the failed items instead.
+ */
+export const buildSendMessages =
+  <Contract extends SQSContract>(
+    contract: Contract,
+    options: SendMessagesBuilderOptions<Contract>,
+  ): SendMessagesSideEffect<Contract> =>
+  async messages => {
+    const internalOptions = {
+      ...defaultOptions,
+      ...options,
+    };
+    const { bodySerializer } = internalOptions;
+
+    validateMessages<Contract>({
+      contract,
+      messages,
+      options: internalOptions,
+    });
+
+    return sendBatchedMessages<Contract>({
+      messages: messages.map<SendMessageBatchRequestEntry>(
+        serializeMessage<Contract>({ contract, bodySerializer }),
+      ),
+      options: internalOptions,
+    });
+  };

--- a/packages/serverless-contracts/src/contracts/SQS/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/index.ts
@@ -1,5 +1,5 @@
 export { SQSContract } from './sqsContract';
-export { getSQSHandler, getLambdaSQSHandler } from './features';
+export { getSQSHandler } from './features';
 export type {
   SQSHandler,
   SwarmionSQSHandler,

--- a/packages/serverless-contracts/src/contracts/SQS/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/index.ts
@@ -1,3 +1,9 @@
 export { SQSContract } from './sqsContract';
-export { getSQSHandler } from './features';
-export type { SQSHandler, SwarmionSQSHandler } from './types';
+export { getSQSHandler, getLambdaSQSHandler } from './features';
+export type {
+  SQSHandler,
+  SwarmionSQSHandler,
+  SwarmionLambdaSQSHandler,
+  GetSQSHandlerOptions,
+  SwarmionSQSRecord,
+} from './types';

--- a/packages/serverless-contracts/src/contracts/SQS/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/index.ts
@@ -1,1 +1,3 @@
 export { SQSContract } from './sqsContract';
+export { getSQSHandler } from './features';
+export type { SQSHandler, SwarmionSQSHandler } from './types';

--- a/packages/serverless-contracts/src/contracts/SQS/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/index.ts
@@ -1,0 +1,1 @@
+export { SQSContract } from './sqsContract';

--- a/packages/serverless-contracts/src/contracts/SQS/sqsContract.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/sqsContract.ts
@@ -11,6 +11,8 @@ import { StringOrNumberDictionaryJSONSchema } from 'types/constrainedJSONSchema'
  * - input and output dynamic validation with JSONSchemas on both end of the contract;
  * - type inference for both input and output;
  * - generation of a contract document that can be checked for breaking changes;
+ * - simplify implementation of partial batch processing according to best practices
+ * (see https://docs.aws.amazon.com/prescriptive-guidance/latest/lambda-event-filtering-partial-batch-responses-for-sqs/best-practices-partial-batch-responses.html).
  */
 export class SQSContract<
   MessageBodySchema extends JSONSchema = JSONSchema,

--- a/packages/serverless-contracts/src/contracts/SQS/sqsContract.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/sqsContract.ts
@@ -1,0 +1,57 @@
+import { JSONSchema } from 'json-schema-to-ts';
+
+import { StringOrNumberDictionaryJSONSchema } from 'types/constrainedJSONSchema';
+
+/**
+ * SQSContract:
+ *
+ * a contract used to define a type-safe interaction between AWS Services through SimpleQueueService (SQS).
+ *
+ * Main features:
+ * - input and output dynamic validation with JSONSchemas on both end of the contract;
+ * - type inference for both input and output;
+ * - generation of a contract document that can be checked for breaking changes;
+ */
+export class SQSContract<
+  MessageBodySchema extends JSONSchema = JSONSchema,
+  MessageAttributesSchema extends
+    StringOrNumberDictionaryJSONSchema = StringOrNumberDictionaryJSONSchema,
+> {
+  public id: string;
+  public contractType = 'SQS' as const;
+  public messageBodySchema: MessageBodySchema;
+  public messageAttributesSchema: MessageAttributesSchema;
+
+  /**
+   * Builds a new SQSContract contract
+   */
+  constructor({
+    id,
+    messageBodySchema,
+    messageAttributesSchema,
+  }: {
+    /**
+     * A unique id to identify the contract among stacks. Beware uniqueness!
+     */
+    id: string;
+    /**
+     * A JSONSchema used to validate the message body and infer its type.
+     *
+     * Please note that the `as const` directive is necessary to properly infer the type from the schema.
+     * See https://github.com/ThomasAribart/json-schema-to-ts#fromschema.
+     */
+    messageBodySchema: MessageBodySchema;
+    /**
+     * A JSONSchema used to validate the message attributes and infer its type.
+     *
+     * Please note that the `as const` directive is necessary to properly infer the type from the schema.
+     * See https://github.com/ThomasAribart/json-schema-to-ts#fromschema.
+     */
+    messageAttributesSchema?: MessageAttributesSchema;
+  }) {
+    this.id = id;
+    this.messageBodySchema = messageBodySchema;
+    this.messageAttributesSchema =
+      messageAttributesSchema ?? ({} as MessageAttributesSchema);
+  }
+}

--- a/packages/serverless-contracts/src/contracts/SQS/types/common.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/common.ts
@@ -17,6 +17,7 @@ export type SqsMessage<Contract extends SQSContract> = Omit<
   SendMessageRequest,
   'MessageBody' | 'QueueUrl'
 > & {
+  Id?: string;
   body: SqsMessageBodyType<Contract>;
   // TODO improve messageAttributes type to be required when SqsMessageAttributesType is a valid json schema
   messageAttributes?: SqsMessageAttributesType<Contract>;

--- a/packages/serverless-contracts/src/contracts/SQS/types/common.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/common.ts
@@ -1,3 +1,4 @@
+import { SendMessageRequest } from '@aws-sdk/client-sqs';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 
 import { SQSContract } from '../sqsContract';
@@ -11,3 +12,12 @@ export type SqsMessageAttributesType<Contract extends SQSContract> =
   Contract['messageAttributesSchema'] extends JSONSchema
     ? FromSchema<Contract['messageAttributesSchema']>
     : void;
+
+export type SqsMessage<Contract extends SQSContract> = Omit<
+  SendMessageRequest,
+  'MessageBody' | 'QueueUrl'
+> & {
+  body: SqsMessageBodyType<Contract>;
+  // TODO improve messageAttributes type to be required when SqsMessageAttributesType is a valid json schema
+  messageAttributes?: SqsMessageAttributesType<Contract>;
+};

--- a/packages/serverless-contracts/src/contracts/SQS/types/common.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/common.ts
@@ -1,0 +1,13 @@
+import { FromSchema, JSONSchema } from 'json-schema-to-ts';
+
+import { SQSContract } from '../sqsContract';
+
+export type SqsMessageBodyType<Contract extends SQSContract> =
+  Contract['messageBodySchema'] extends JSONSchema
+    ? FromSchema<Contract['messageBodySchema']>
+    : void;
+
+export type SqsMessageAttributesType<Contract extends SQSContract> =
+  Contract['messageAttributesSchema'] extends JSONSchema
+    ? FromSchema<Contract['messageAttributesSchema']>
+    : void;

--- a/packages/serverless-contracts/src/contracts/SQS/types/fullContract.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/fullContract.ts
@@ -1,0 +1,19 @@
+import { SQSContract } from '../sqsContract';
+
+/**
+ * Computed schema type of the input validation schema.
+ *
+ * Can be used with `FromSchema` to infer the type of the contract of the lambda
+ */
+export interface FullContractSchemaType<Contract extends SQSContract> {
+  type: 'object';
+  properties: {
+    id: { const: Contract['id'] };
+    contractType: { const: Contract['contractType'] };
+    messageBodySchema: Contract['messageBodySchema'];
+    messageAttributesSchema?: NonNullable<Contract['messageAttributesSchema']>;
+  };
+  required: ['id', 'contractType', 'messageBodySchema'];
+  additionalProperties: false;
+  [key: string]: unknown;
+}

--- a/packages/serverless-contracts/src/contracts/SQS/types/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/index.ts
@@ -1,0 +1,2 @@
+export * from './fullContract';
+export * from './common';

--- a/packages/serverless-contracts/src/contracts/SQS/types/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/index.ts
@@ -1,2 +1,3 @@
 export * from './fullContract';
 export * from './common';
+export * from './lambdaHandler';

--- a/packages/serverless-contracts/src/contracts/SQS/types/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/index.ts
@@ -1,3 +1,4 @@
 export * from './fullContract';
 export * from './common';
 export * from './lambdaHandler';
+export * from './sendMessage';

--- a/packages/serverless-contracts/src/contracts/SQS/types/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/lambdaHandler.ts
@@ -1,0 +1,67 @@
+import Ajv from 'ajv';
+import { SQSHandler as AwsSQSHandler, SQSRecord } from 'aws-lambda';
+
+/**
+ * getHandler options for SQSContract
+ */
+export type GetSQSHandlerOptions =
+  | {
+      bodyParser?: ((body: string) => unknown) | undefined; // Default is JSON.parse. Pass explicit undefined bodyParser to avoid bodyParsing
+      ajv: Ajv;
+      validateBody?: boolean;
+      validateAttributes?: boolean;
+    }
+  | {
+      bodyParser?: ((body: string) => unknown) | undefined; // Default is JSON.parse. Pass explicit undefined bodyParser to avoid bodyParsing
+      ajv?: Ajv;
+      validateBody: false;
+      validateAttributes: false;
+    };
+
+export type DefaultGetSQSHandlerOptions = {
+  bodyParser: (body: string) => unknown;
+  validateBody: true;
+  validateAttributes: boolean;
+  ajv?: undefined;
+};
+
+/**
+ * a simple helper type to build EventBridgeHandler
+ */
+type SQSHandlerParameters = Parameters<AwsSQSHandler>;
+
+/**
+ * The type of an SQS handler. This is the actual version that will
+ * be executed by the lambda, not the Swarmion inferred one.
+ *
+ * See https://docs.aws.amazon.com/lambda/latest/dg/typescript-handler.html.
+ */
+export type SQSHandler<AdditionalArgs extends unknown[]> = (
+  event: SQSHandlerParameters[0],
+  context: SQSHandlerParameters[1],
+  callback: SQSHandlerParameters[2],
+  ...additionalArgs: AdditionalArgs
+) => Promise<unknown>;
+
+export type SwarmionSQSRecord<MessageBody, MessageAttributes> = Omit<
+  SQSRecord,
+  'body' | 'messageAttributes'
+> & {
+  body: MessageBody;
+  messageAttributes: MessageAttributes;
+};
+
+/**
+ * The type of the basic Swarmion handler, with type-inferred event
+ * The handler function can define additional arguments
+ */
+export type SwarmionSQSHandler<
+  MessageBody,
+  MessageAttributes,
+  AdditionalArgs extends unknown[],
+> = (
+  event: { Records: SwarmionSQSRecord<MessageBody, MessageAttributes>[] },
+  context: SQSHandlerParameters[1],
+  callback?: SQSHandlerParameters[2],
+  ...additionalArgs: AdditionalArgs
+) => Promise<unknown>;

--- a/packages/serverless-contracts/src/contracts/SQS/types/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/lambdaHandler.ts
@@ -26,9 +26,9 @@ export type DefaultGetSQSHandlerOptions = {
 };
 
 /**
- * a simple helper type to build EventBridgeHandler
+ * a simple helper type to build SQSHandler
  */
-type SQSHandlerParameters = Parameters<AwsSQSHandler>;
+export type SQSHandlerParameters = Parameters<AwsSQSHandler>;
 
 /**
  * The type of an SQS handler. This is the actual version that will
@@ -52,7 +52,30 @@ export type SwarmionSQSRecord<MessageBody, MessageAttributes> = Omit<
 };
 
 /**
- * The type of the basic Swarmion handler, with type-inferred event
+ * The type of the basic Swarmion handler for SQS,
+ * It receives all the records parsed and with their inferred type.
+ * It must process all the records and handle errors if necessary.
+ * Use SwarmionSQSHandler to avoid handling the whole batch, and to automatically process errors.
+ * The handler function can define additional arguments
+ */
+export type SwarmionLambdaSQSHandler<
+  MessageBody,
+  MessageAttributes,
+  AdditionalArgs extends unknown[],
+> = (
+  event: { records: SwarmionSQSRecord<MessageBody, MessageAttributes>[] },
+  context: SQSHandlerParameters[1],
+  callback?: SQSHandlerParameters[2],
+  ...additionalArgs: AdditionalArgs
+) => Promise<unknown>;
+
+/**
+ * The type of the Swarmion handler for SQS.
+ * It receives only one record of the batch.
+ * The record is parsed and with its inferred type.
+ * It can throw an error if the record is invalid. The wrapper will catch it
+ * and inform the SQS that the record couldn't be processed following the batch failure reporting spec.
+ * https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
  * The handler function can define additional arguments
  */
 export type SwarmionSQSHandler<
@@ -60,7 +83,7 @@ export type SwarmionSQSHandler<
   MessageAttributes,
   AdditionalArgs extends unknown[],
 > = (
-  event: { Records: SwarmionSQSRecord<MessageBody, MessageAttributes>[] },
+  event: SwarmionSQSRecord<MessageBody, MessageAttributes>,
   context: SQSHandlerParameters[1],
   callback?: SQSHandlerParameters[2],
   ...additionalArgs: AdditionalArgs

--- a/packages/serverless-contracts/src/contracts/SQS/types/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/lambdaHandler.ts
@@ -4,18 +4,20 @@ import { SQSHandler as AwsSQSHandler, SQSRecord } from 'aws-lambda';
 /**
  * getHandler options for SQSContract
  */
-export type GetSQSHandlerOptions =
+export type GetSQSHandlerOptions<HandleRecords extends boolean> =
   | {
       bodyParser?: ((body: string) => unknown) | undefined; // Default is JSON.parse. Pass explicit undefined bodyParser to avoid bodyParsing
       ajv: Ajv;
       validateBody?: boolean;
       validateAttributes?: boolean;
+      handleBatchedRecords?: HandleRecords;
     }
   | {
       bodyParser?: ((body: string) => unknown) | undefined; // Default is JSON.parse. Pass explicit undefined bodyParser to avoid bodyParsing
       ajv?: Ajv;
       validateBody: false;
       validateAttributes: false;
+      handleBatchedRecords?: HandleRecords;
     };
 
 export type DefaultGetSQSHandlerOptions = {
@@ -23,6 +25,7 @@ export type DefaultGetSQSHandlerOptions = {
   validateBody: true;
   validateAttributes: boolean;
   ajv?: undefined;
+  handleBatchedRecords: true;
 };
 
 /**

--- a/packages/serverless-contracts/src/contracts/SQS/types/sendMessage.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/sendMessage.ts
@@ -1,0 +1,29 @@
+import { SQSClient } from '@aws-sdk/client-sqs';
+import Ajv from 'ajv';
+
+import { SqsMessage, SqsMessageBodyType } from './common';
+import { SQSContract } from '../sqsContract';
+
+export type SendMessageBuilderOptions<Contract extends SQSContract> =
+  | {
+      queueUrl: string | (() => string);
+      sqsClient: SQSClient;
+      ajv: Ajv;
+      validateMessage?: boolean;
+      bodySerializer?: (
+        body: SqsMessageBodyType<Contract>,
+      ) => string | undefined; // Use explicit undefined to disable body serialization
+    }
+  | {
+      queueUrl: string | (() => string);
+      sqsClient: SQSClient;
+      ajv?: Ajv;
+      validateMessage: false;
+      bodySerializer?: (
+        body: SqsMessageBodyType<Contract>,
+      ) => string | undefined; // Use explicit undefined to disable body serialization
+    };
+
+export type SendMessageSideEffect<Contract extends SQSContract> = (
+  message: SqsMessage<Contract>,
+) => Promise<void>;

--- a/packages/serverless-contracts/src/contracts/SQS/types/sendMessage.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/types/sendMessage.ts
@@ -1,29 +1,39 @@
-import { SQSClient } from '@aws-sdk/client-sqs';
+import {
+  BatchResultErrorEntry,
+  SendMessageResult,
+  SQSClient,
+} from '@aws-sdk/client-sqs';
 import Ajv from 'ajv';
 
 import { SqsMessage, SqsMessageBodyType } from './common';
 import { SQSContract } from '../sqsContract';
 
-export type SendMessageBuilderOptions<Contract extends SQSContract> =
+export type SendMessageBuilderOptions<Contract extends SQSContract> = (
   | {
-      queueUrl: string | (() => string);
-      sqsClient: SQSClient;
       ajv: Ajv;
       validateMessage?: boolean;
-      bodySerializer?: (
-        body: SqsMessageBodyType<Contract>,
-      ) => string | undefined; // Use explicit undefined to disable body serialization
     }
   | {
-      queueUrl: string | (() => string);
-      sqsClient: SQSClient;
       ajv?: Ajv;
       validateMessage: false;
-      bodySerializer?: (
-        body: SqsMessageBodyType<Contract>,
-      ) => string | undefined; // Use explicit undefined to disable body serialization
-    };
+    }
+) & {
+  queueUrl: string | (() => string);
+  sqsClient: SQSClient;
+  bodySerializer?: (body: SqsMessageBodyType<Contract>) => string | undefined; // Use explicit undefined to disable body serialization
+};
+
+export type SendMessagesBuilderOptions<Contract extends SQSContract> =
+  SendMessageBuilderOptions<Contract> & {
+    maxRetries?: number;
+    baseDelay?: number;
+    throwOnFailedBatch?: boolean;
+  };
 
 export type SendMessageSideEffect<Contract extends SQSContract> = (
   message: SqsMessage<Contract>,
-) => Promise<void>;
+) => Promise<SendMessageResult>;
+
+export type SendMessagesSideEffect<Contract extends SQSContract> = (
+  messages: SqsMessage<Contract>[],
+) => Promise<{ failedItems: BatchResultErrorEntry[] }>;

--- a/packages/serverless-contracts/src/contracts/SQS/utils/allRecordsHandler.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/allRecordsHandler.ts
@@ -1,0 +1,60 @@
+import type { SQSBatchResponse } from 'aws-lambda/trigger/sqs';
+
+import {
+  SQSHandlerParameters,
+  SwarmionSQSHandler,
+  SwarmionSQSRecord,
+} from '../types';
+
+export const getAllRecordsHandler =
+  <MessageBody, MessageAttributes, AdditionalArgs extends unknown[]>(
+    handleRecord: SwarmionSQSHandler<
+      MessageBody,
+      MessageAttributes,
+      AdditionalArgs
+    >,
+    context: SQSHandlerParameters[1],
+    callback: SQSHandlerParameters[2],
+    additionalArgs: AdditionalArgs,
+  ) =>
+  async (event: {
+    records: SwarmionSQSRecord<MessageBody, MessageAttributes>[];
+  }): Promise<SQSBatchResponse> => {
+    const { records } = event;
+
+    const handleRecordsResults = await Promise.allSettled(
+      records.map(record =>
+        handleRecord(record, context, callback, ...additionalArgs),
+      ),
+    );
+
+    const recordsErrors = handleRecordsResults
+      .map((recordResult, index) => ({
+        ...recordResult,
+        record: records[index],
+      }))
+      .filter(
+        (
+          record,
+        ): record is PromiseRejectedResult & {
+          record: SwarmionSQSRecord<MessageBody, MessageAttributes>;
+        } => record.status === 'rejected',
+      );
+
+    recordsErrors.forEach(({ record, reason }) => {
+      console.error(
+        `Error during the processing of the message ${record.messageId}`,
+        { record },
+        reason,
+      );
+      console.error(
+        `Message ${record.messageId} will be marked as failed and be retried according to the SQS retry configuration`,
+      );
+    });
+
+    return {
+      batchItemFailures: recordsErrors.map(({ record: { messageId } }) => ({
+        itemIdentifier: messageId,
+      })),
+    };
+  };

--- a/packages/serverless-contracts/src/contracts/SQS/utils/chunckSQSMessagesBatch.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/chunckSQSMessagesBatch.ts
@@ -1,0 +1,64 @@
+import { SendMessageBatchRequestEntry } from '@aws-sdk/client-sqs';
+
+type ChunkedMessagesAccumulator = {
+  chunkedEntries: SendMessageBatchRequestEntry[][];
+  lastChunkSize: number;
+  lastChunkLength: number;
+};
+
+const MAX_BATCH_SIZE = 256000; // 256Kb
+const MAX_BATCH_LENGTH = 10;
+
+export class MaxSizeExceededError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MaxSizeExceededError';
+  }
+}
+
+const computeMessageSize = (message: SendMessageBatchRequestEntry): number =>
+  Buffer.byteLength(JSON.stringify(message), 'utf8'); // This is not accurate must be a good upper approximation
+
+export const chunkSQSMessagesBatch = (
+  messages: SendMessageBatchRequestEntry[],
+): ChunkedMessagesAccumulator['chunkedEntries'] =>
+  messages.reduce<ChunkedMessagesAccumulator>(
+    (
+      chunkedEntriesAccumulator: ChunkedMessagesAccumulator,
+      entry: SendMessageBatchRequestEntry,
+    ) => {
+      const { chunkedEntries, lastChunkSize, lastChunkLength } =
+        chunkedEntriesAccumulator;
+      const eventSize = computeMessageSize(entry);
+      if (eventSize > MAX_BATCH_SIZE) {
+        throw new MaxSizeExceededError(
+          `Message ${entry.Id} size is ${eventSize}b exceeds the maximum batch size of ${MAX_BATCH_SIZE}b. 
+          The whole operation has been cancelled. No message have been sent to SQS.`,
+        );
+      }
+
+      if (
+        lastChunkSize + eventSize > MAX_BATCH_SIZE ||
+        lastChunkLength === MAX_BATCH_LENGTH
+      ) {
+        return {
+          chunkedEntries: [...chunkedEntries, [entry]],
+          lastChunkSize: eventSize,
+          lastChunkLength: 1,
+        };
+      }
+
+      const lastChunk = chunkedEntries.pop() ?? [];
+
+      return {
+        chunkedEntries: [...chunkedEntries, [...lastChunk, entry]],
+        lastChunkSize: lastChunkSize + eventSize,
+        lastChunkLength: lastChunkLength + 1,
+      };
+    },
+    {
+      chunkedEntries: [],
+      lastChunkSize: 0,
+      lastChunkLength: 0,
+    },
+  ).chunkedEntries;

--- a/packages/serverless-contracts/src/contracts/SQS/utils/delays.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/delays.ts
@@ -1,0 +1,7 @@
+export const wait = async (ms = 100): Promise<void> =>
+  new Promise<void>(resolve => setTimeout(resolve, ms));
+
+export const getExponentialBackoffDelay = (
+  retryCount: number,
+  baseDelayMs = 1,
+): number => baseDelayMs * 10 ** retryCount;

--- a/packages/serverless-contracts/src/contracts/SQS/utils/getRecordsValidator.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/getRecordsValidator.ts
@@ -2,7 +2,7 @@ import { ValidateFunction } from 'ajv';
 import { JSONSchema } from 'json-schema-to-ts';
 
 import { SQSContract } from '../sqsContract';
-import { GetSQSHandlerOptions } from '../types';
+import { GetSQSHandlerOptions, SendMessageBuilderOptions } from '../types';
 
 export const getSchema = <Contract extends SQSContract>(
   contract: Contract,
@@ -49,4 +49,29 @@ export const getRecordsValidator = <Contract extends SQSContract>(
   return recordsValidationSchema !== undefined
     ? options.ajv?.compile(recordsValidationSchema)
     : undefined;
+};
+
+export const getBodyValidator = <Contract extends SQSContract>(
+  contract: Contract,
+  options: SendMessageBuilderOptions<Contract>,
+): ValidateFunction | undefined => {
+  if (options.validateMessage === false) {
+    return;
+  }
+
+  return options.ajv.compile(contract.messageBodySchema);
+};
+
+export const getMessageAttributesValidator = <Contract extends SQSContract>(
+  contract: Contract,
+  options: SendMessageBuilderOptions<Contract>,
+): ValidateFunction | undefined => {
+  if (
+    options.validateMessage === false ||
+    Object.keys(contract.messageAttributesSchema).length === 0
+  ) {
+    return;
+  }
+
+  return options.ajv.compile(contract.messageAttributesSchema);
 };

--- a/packages/serverless-contracts/src/contracts/SQS/utils/getRecordsValidator.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/getRecordsValidator.ts
@@ -6,7 +6,7 @@ import { GetSQSHandlerOptions, SendMessageBuilderOptions } from '../types';
 
 export const getSchema = <Contract extends SQSContract>(
   contract: Contract,
-  { validateBody, validateAttributes }: GetSQSHandlerOptions,
+  { validateBody, validateAttributes }: GetSQSHandlerOptions<boolean>,
 ): JSONSchema | undefined => ({
   type: 'array',
   items: {
@@ -27,7 +27,7 @@ export const getSchema = <Contract extends SQSContract>(
 
 const getRecordsValidationSchema = <Contract extends SQSContract>(
   contract: Contract,
-  options: GetSQSHandlerOptions,
+  options: GetSQSHandlerOptions<boolean>,
 ): JSONSchema | undefined => {
   const { validateBody, validateAttributes } = options;
   if (
@@ -42,7 +42,7 @@ const getRecordsValidationSchema = <Contract extends SQSContract>(
 
 export const getRecordsValidator = <Contract extends SQSContract>(
   contract: Contract,
-  options: GetSQSHandlerOptions,
+  options: GetSQSHandlerOptions<boolean>,
 ): ValidateFunction | undefined => {
   const recordsValidationSchema = getRecordsValidationSchema(contract, options);
 

--- a/packages/serverless-contracts/src/contracts/SQS/utils/getRecordsValidator.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/getRecordsValidator.ts
@@ -1,0 +1,52 @@
+import { ValidateFunction } from 'ajv';
+import { JSONSchema } from 'json-schema-to-ts';
+
+import { SQSContract } from '../sqsContract';
+import { GetSQSHandlerOptions } from '../types';
+
+export const getSchema = <Contract extends SQSContract>(
+  contract: Contract,
+  { validateBody, validateAttributes }: GetSQSHandlerOptions,
+): JSONSchema | undefined => ({
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      ...(validateBody === true && { body: contract.messageBodySchema }),
+      ...(validateAttributes === true && {
+        messageAttributes: contract.messageAttributesSchema,
+      }),
+    },
+    required: [
+      ...(validateBody !== undefined ? ['body'] : []),
+      ...(validateAttributes !== undefined ? ['messageAttributes'] : []),
+    ],
+    additionalProperties: true,
+  },
+});
+
+const getRecordsValidationSchema = <Contract extends SQSContract>(
+  contract: Contract,
+  options: GetSQSHandlerOptions,
+): JSONSchema | undefined => {
+  const { validateBody, validateAttributes } = options;
+  if (
+    (validateBody === undefined || !validateBody) &&
+    (validateAttributes === undefined || !validateAttributes)
+  ) {
+    return undefined;
+  }
+
+  return getSchema(contract, options);
+};
+
+export const getRecordsValidator = <Contract extends SQSContract>(
+  contract: Contract,
+  options: GetSQSHandlerOptions,
+): ValidateFunction | undefined => {
+  const recordsValidationSchema = getRecordsValidationSchema(contract, options);
+
+  return recordsValidationSchema !== undefined
+    ? options.ajv?.compile(recordsValidationSchema)
+    : undefined;
+};

--- a/packages/serverless-contracts/src/contracts/SQS/utils/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/index.ts
@@ -2,3 +2,7 @@ export * from './parseRecord';
 export * from './getRecordsValidator';
 export * from './allRecordsHandler';
 export * from './serializeMessageAttributes';
+export * from './messagesValidation';
+export * from './serializeMessage';
+export * from './delays';
+export * from './chunckSQSMessagesBatch';

--- a/packages/serverless-contracts/src/contracts/SQS/utils/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './parseRecord';
 export * from './getRecordsValidator';
+export * from './allRecordsHandler';

--- a/packages/serverless-contracts/src/contracts/SQS/utils/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './parseRecord';
 export * from './getRecordsValidator';
 export * from './allRecordsHandler';
+export * from './serializeMessageAttributes';

--- a/packages/serverless-contracts/src/contracts/SQS/utils/index.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './parseRecord';
+export * from './getRecordsValidator';

--- a/packages/serverless-contracts/src/contracts/SQS/utils/messagesValidation.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/messagesValidation.ts
@@ -1,0 +1,74 @@
+import {
+  getBodyValidator,
+  getMessageAttributesValidator,
+} from './getRecordsValidator';
+import { SQSContract } from '../sqsContract';
+import { SendMessageBuilderOptions, SqsMessage } from '../types';
+
+export const validateMessage = <Contract extends SQSContract>({
+  contract,
+  message,
+  options,
+  index,
+}: {
+  contract: Contract;
+  message: SqsMessage<Contract>;
+  options: SendMessageBuilderOptions<Contract>;
+  index?: number;
+}): void => {
+  const { body, messageAttributes } = message;
+
+  const bodyValidator = getBodyValidator<Contract>(contract, options);
+  if (bodyValidator !== undefined && !bodyValidator(body)) {
+    console.error(
+      `Error: Invalid message body ${
+        index !== undefined ? `at index ${index}` : ''
+      }`,
+      JSON.stringify(bodyValidator.errors, null, 2),
+    );
+    throw new Error('Error: Invalid message body');
+  }
+
+  if (messageAttributes === undefined) {
+    return;
+  }
+
+  const messageAttributesValidator = getMessageAttributesValidator<Contract>(
+    contract,
+    options,
+  );
+  if (
+    messageAttributesValidator !== undefined &&
+    !messageAttributesValidator(messageAttributes)
+  ) {
+    console.error(
+      `Error: Invalid message attributes ${
+        index !== undefined ? `at index ${index}` : ''
+      }`,
+      JSON.stringify(messageAttributesValidator.errors, null, 2),
+    );
+    throw new Error('Error: Invalid message attributes');
+  }
+};
+
+export const validateMessages = <Contract extends SQSContract>({
+  contract,
+  messages,
+  options,
+}: {
+  contract: Contract;
+  messages: SqsMessage<Contract>[];
+  options: SendMessageBuilderOptions<Contract>;
+}): void => {
+  const errors = [];
+  messages.forEach((message, index) => {
+    try {
+      validateMessage<Contract>({ contract, message, options, index });
+    } catch (error) {
+      errors.push(error);
+    }
+  });
+  if (errors.length > 0) {
+    throw new Error('Error: Invalid message');
+  }
+};

--- a/packages/serverless-contracts/src/contracts/SQS/utils/parseMessageAttributes.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/parseMessageAttributes.ts
@@ -1,0 +1,35 @@
+import {
+  SQSMessageAttribute,
+  SQSMessageAttributeDataType,
+  SQSRecord,
+} from 'aws-lambda';
+
+const parseDataType = (
+  dataType: SQSMessageAttributeDataType,
+): 'String' | 'Number' | 'Binary' =>
+  dataType.split('.')[0] as 'String' | 'Number' | 'Binary';
+const parseMessageAttribute = (attribute: SQSMessageAttribute): unknown => {
+  const dataType = parseDataType(attribute.dataType);
+  switch (dataType) {
+    case 'Binary':
+      return attribute.binaryValue;
+    case 'String':
+      return attribute.stringValue;
+    case 'Number':
+      return Number(attribute.stringValue);
+  }
+};
+export const parseMessageAttributes = <
+  MessageAttributes extends Record<string, unknown>,
+>(
+  messageAttributes: SQSRecord['messageAttributes'],
+): MessageAttributes =>
+  Object.entries(messageAttributes).reduce<MessageAttributes>(
+    (acc, [attributeName, attribute]) => {
+      return {
+        ...acc,
+        [attributeName]: parseMessageAttribute(attribute),
+      };
+    },
+    {} as MessageAttributes,
+  );

--- a/packages/serverless-contracts/src/contracts/SQS/utils/parseRecord.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/parseRecord.ts
@@ -4,7 +4,9 @@ import { parseMessageAttributes } from './parseMessageAttributes';
 import { GetSQSHandlerOptions, SwarmionSQSRecord } from '../types';
 
 export const parseRecord =
-  <MessageBody, MessageAttributes>({ bodyParser }: GetSQSHandlerOptions) =>
+  <MessageBody, MessageAttributes>({
+    bodyParser,
+  }: GetSQSHandlerOptions<boolean>) =>
   ({
     body,
     messageAttributes,

--- a/packages/serverless-contracts/src/contracts/SQS/utils/parseRecord.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/parseRecord.ts
@@ -1,0 +1,21 @@
+import { SQSRecord } from 'aws-lambda';
+
+import { parseMessageAttributes } from './parseMessageAttributes';
+import { GetSQSHandlerOptions, SwarmionSQSRecord } from '../types';
+
+export const parseRecord =
+  <MessageBody, MessageAttributes>({ bodyParser }: GetSQSHandlerOptions) =>
+  ({
+    body,
+    messageAttributes,
+    ...rest
+  }: SQSRecord): SwarmionSQSRecord<MessageBody, MessageAttributes> => ({
+    ...rest,
+    body:
+      bodyParser !== undefined
+        ? (bodyParser(body) as MessageBody) // Validation is done after
+        : (body as MessageBody), // Validation is done after
+    messageAttributes: parseMessageAttributes(
+      messageAttributes,
+    ) as MessageAttributes, // Validation is done after
+  });

--- a/packages/serverless-contracts/src/contracts/SQS/utils/serializeMessage.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/serializeMessage.ts
@@ -1,0 +1,35 @@
+import { SendMessageBatchRequestEntry } from '@aws-sdk/client-sqs';
+import { ulid } from 'ulid';
+
+import { serializeMessageAttributes } from './serializeMessageAttributes';
+import { StringOrNumberDictionaryJSONSchema } from '../../../types/constrainedJSONSchema';
+import { SQSContract } from '../sqsContract';
+import { SqsMessage, SqsMessageBodyType } from '../types';
+
+export const serializeMessage =
+  <Contract extends SQSContract>({
+    contract,
+    bodySerializer,
+  }: {
+    contract: Contract;
+    bodySerializer?: (body: SqsMessageBodyType<Contract>) => string | undefined;
+  }) =>
+  ({
+    body,
+    messageAttributes,
+    ...restMessage
+  }: SqsMessage<Contract>): SendMessageBatchRequestEntry => ({
+    Id: ulid(),
+    MessageBody:
+      // @ts-expect-error weird bodySerializer error: Type instantiation is excessively deep and possibly infinite
+      bodySerializer !== undefined ? bodySerializer(body) : (body as string),
+    ...(messageAttributes !== undefined && messageAttributes !== null
+      ? {
+          MessageAttributes: serializeMessageAttributes(
+            messageAttributes as unknown as StringOrNumberDictionaryJSONSchema, // messageAttributes generic infered type has {} as type. I don't know why
+            contract,
+          ),
+        }
+      : {}),
+    ...restMessage,
+  });

--- a/packages/serverless-contracts/src/contracts/SQS/utils/serializeMessageAttributes.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/utils/serializeMessageAttributes.ts
@@ -1,0 +1,62 @@
+import { SendMessageRequest } from '@aws-sdk/client-sqs';
+import { MessageAttributeValue } from '@aws-sdk/client-sqs/dist-types/models/models_0';
+import { JSONSchema } from 'json-schema-to-ts';
+
+import { StringOrNumberDictionaryJSONSchema } from '../../../types/constrainedJSONSchema';
+import { SQSContract } from '../sqsContract';
+
+const serializeMessageAttribute = (
+  attributeValue: unknown,
+  attributeSchema: JSONSchema,
+): MessageAttributeValue => {
+  if (typeof attributeSchema === 'boolean') {
+    throw new Error('Invalid contract messageAttributesSchema');
+  }
+  const { type } = attributeSchema;
+
+  switch (type) {
+    case 'string':
+      return { StringValue: attributeValue as string, DataType: 'String' };
+    case 'number':
+      return {
+        StringValue: (attributeValue as number).toString(),
+        DataType: 'Number',
+      };
+    default:
+      throw new Error(
+        'Invalid messageAttributesSchema. Only string and number are currently supported',
+      );
+  }
+};
+export const serializeMessageAttributes = <
+  MessageAttributes extends StringOrNumberDictionaryJSONSchema,
+  Contract extends SQSContract,
+>(
+  messageAttributes: MessageAttributes,
+  contract: Contract,
+): SendMessageRequest['MessageAttributes'] => {
+  const { properties } = contract.messageAttributesSchema;
+
+  if (properties === undefined) {
+    throw new Error('Invalid contract messageAttributesSchema');
+  }
+
+  return Object.entries(properties).reduce<
+    SendMessageRequest['MessageAttributes']
+  >(
+    (acc, [attributeName, attributeSchema]) => {
+      if (messageAttributes[attributeName] === undefined) {
+        return acc;
+      }
+
+      return {
+        ...acc,
+        [attributeName]: serializeMessageAttribute(
+          messageAttributes[attributeName],
+          attributeSchema,
+        ),
+      };
+    },
+    {} as SendMessageRequest['MessageAttributes'],
+  );
+};

--- a/packages/serverless-contracts/src/contracts/apiGateway/__tests__/fetchRequest.test.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/__tests__/fetchRequest.test.ts
@@ -6,15 +6,16 @@ import { HttpStatusCodes } from 'types/http';
 import { ApiGatewayContract } from '../apiGatewayContract';
 import { getFetchRequest } from '../features/fetchRequest';
 
-const mockedFetch = vi.fn(() =>
-  Promise.resolve({
-    json: () => {
-      return Promise.resolve(undefined);
-    },
-  }),
-);
+const mockedFetch = vi.fn();
 
 describe('apiGateway fetch request', () => {
+  beforeEach(() => {
+    mockedFetch.mockResolvedValue({
+      json: () => {
+        return Promise.resolve(undefined);
+      },
+    });
+  });
   const pathParametersSchema = {
     type: 'object',
     properties: { userId: { type: 'string' }, pageNumber: { type: 'string' } },

--- a/packages/serverless-contracts/src/contracts/apiGateway/apiGatewayContract.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/apiGatewayContract.ts
@@ -3,7 +3,7 @@ import { JSONSchema } from 'json-schema-to-ts';
 import isUndefined from 'lodash/isUndefined.js';
 import omitBy from 'lodash/omitBy.js';
 
-import { ConstrainedJSONSchema } from 'types/constrainedJSONSchema';
+import { StringDictionaryJSONSchema } from 'types/constrainedJSONSchema';
 import { HttpMethod, HttpStatusCodes } from 'types/http';
 
 import {
@@ -27,11 +27,13 @@ export class ApiGatewayContract<
   Method extends HttpMethod = HttpMethod,
   IntegrationType extends ApiGatewayIntegrationType = ApiGatewayIntegrationType,
   AuthorizerType extends ApiGatewayAuthorizerType = undefined,
-  PathParametersSchema extends ConstrainedJSONSchema | undefined = undefined,
-  QueryStringParametersSchema extends
-    | ConstrainedJSONSchema
+  PathParametersSchema extends
+    | StringDictionaryJSONSchema
     | undefined = undefined,
-  HeadersSchema extends ConstrainedJSONSchema | undefined = undefined,
+  QueryStringParametersSchema extends
+    | StringDictionaryJSONSchema
+    | undefined = undefined,
+  HeadersSchema extends StringDictionaryJSONSchema | undefined = undefined,
   RequestContextSchema extends JSONSchema | undefined = undefined,
   BodySchema extends JSONSchema | undefined = undefined,
   PropsOutputSchemas extends
@@ -170,9 +172,9 @@ export type GenericApiGatewayContract = ApiGatewayContract<
   HttpMethod,
   ApiGatewayIntegrationType,
   ApiGatewayAuthorizerType,
-  ConstrainedJSONSchema | undefined,
-  ConstrainedJSONSchema | undefined,
-  ConstrainedJSONSchema | undefined,
+  StringDictionaryJSONSchema | undefined,
+  StringDictionaryJSONSchema | undefined,
+  StringDictionaryJSONSchema | undefined,
   JSONSchema | undefined,
   JSONSchema | undefined,
   Partial<Record<HttpStatusCodes, JSONSchema>>

--- a/packages/serverless-contracts/src/contracts/apiGateway/types/common.ts
+++ b/packages/serverless-contracts/src/contracts/apiGateway/types/common.ts
@@ -1,23 +1,23 @@
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import { O } from 'ts-toolbelt';
 
-import { ConstrainedJSONSchema } from 'types/constrainedJSONSchema';
+import { StringDictionaryJSONSchema } from 'types/constrainedJSONSchema';
 
 import { GenericApiGatewayContract } from '../apiGatewayContract';
 
 export type PathParametersType<Contract extends GenericApiGatewayContract> =
-  Contract['pathParametersSchema'] extends ConstrainedJSONSchema
+  Contract['pathParametersSchema'] extends StringDictionaryJSONSchema
     ? FromSchema<Contract['pathParametersSchema']>
     : undefined;
 
 export type QueryStringParametersType<
   Contract extends GenericApiGatewayContract,
-> = Contract['queryStringParametersSchema'] extends ConstrainedJSONSchema
+> = Contract['queryStringParametersSchema'] extends StringDictionaryJSONSchema
   ? FromSchema<Contract['queryStringParametersSchema']>
   : undefined;
 
 export type HeadersType<Contract extends GenericApiGatewayContract> =
-  Contract['headersSchema'] extends ConstrainedJSONSchema
+  Contract['headersSchema'] extends StringDictionaryJSONSchema
     ? FromSchema<Contract['headersSchema']>
     : undefined;
 

--- a/packages/serverless-contracts/src/contracts/index.ts
+++ b/packages/serverless-contracts/src/contracts/index.ts
@@ -1,3 +1,4 @@
 export * from './cloudFormation';
 export * from './apiGateway';
 export * from './eventBridge';
+export * from './SQS';

--- a/packages/serverless-contracts/src/features/fullSchema.ts
+++ b/packages/serverless-contracts/src/features/fullSchema.ts
@@ -1,5 +1,6 @@
 import { JSONSchema } from 'json-schema-to-ts';
 
+import { getFullContractSchema as getSQSFullContractSchema } from 'contracts/SQS/features';
 import { getFullContractSchema as getApiGatewayFullContractSchema } from 'contracts/apiGateway/features';
 import { getFullContractSchema as getCloudFormationFullContractSchema } from 'contracts/cloudFormation/features';
 import { getFullContractSchema as getEventBridgeFullContractSchema } from 'contracts/eventBridge/features';
@@ -19,6 +20,9 @@ export const getContractFullSchema = (
     }
     case 'eventBridge': {
       return getEventBridgeFullContractSchema(contract);
+    }
+    case 'SQS': {
+      return getSQSFullContractSchema(contract);
     }
   }
 };

--- a/packages/serverless-contracts/src/features/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/features/lambdaHandler.ts
@@ -10,6 +10,7 @@ import {
   SQSContract,
   SQSHandler,
   SwarmionEventBridgeHandler,
+  SwarmionLambdaSQSHandler,
   SwarmionSQSHandler,
 } from 'contracts';
 import { GetApiGatewayHandlerOptions } from 'contracts/apiGateway/features';
@@ -94,11 +95,14 @@ export function getHandler<
   Contract extends SQSContract,
   MessageBody = SqsMessageBodyType<Contract>,
   MessageAttributes = SqsMessageAttributesType<Contract>,
+  HandleRecords extends boolean = true,
 >(
   contract: Contract,
-  options: GetSQSHandlerOptions,
+  options: GetSQSHandlerOptions<HandleRecords>,
 ): <AdditionalArgs extends unknown[]>(
-  handler: SwarmionSQSHandler<MessageBody, MessageAttributes, AdditionalArgs>,
+  handler: HandleRecords extends false
+    ? SwarmionLambdaSQSHandler<MessageBody, MessageAttributes, AdditionalArgs>
+    : SwarmionSQSHandler<MessageBody, MessageAttributes, AdditionalArgs>,
 ) => SQSHandler<AdditionalArgs>;
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
@@ -118,7 +122,7 @@ export function getHandler<Contract extends ServerlessContract>(
         options as GetApiGatewayHandlerOptions,
       );
     case 'SQS':
-      return getSQSHandler(contract, options as GetSQSHandlerOptions);
+      return getSQSHandler(contract, options as GetSQSHandlerOptions<boolean>);
     case 'cloudFormation':
       throw new Error('CloudFormation contract has no handler');
     default:

--- a/packages/serverless-contracts/src/features/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/features/lambdaHandler.ts
@@ -93,6 +93,8 @@ export function getHandler<Contract extends ServerlessContract>(
         contract,
         options as GetApiGatewayHandlerOptions,
       );
+    case 'SQS':
+      throw new Error('SQS contract handler is not implemented yet');
     case 'cloudFormation':
       throw new Error('CloudFormation contract has no handler');
     default:

--- a/packages/serverless-contracts/src/features/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/features/lambdaHandler.ts
@@ -6,7 +6,11 @@ import {
   GenericApiGatewayContract,
   getApiGatewayHandler,
   getEventBridgeHandler,
+  getSQSHandler,
+  SQSContract,
+  SQSHandler,
   SwarmionEventBridgeHandler,
+  SwarmionSQSHandler,
 } from 'contracts';
 import { GetApiGatewayHandlerOptions } from 'contracts/apiGateway/features';
 import {
@@ -24,6 +28,12 @@ import {
 } from 'contracts/apiGateway/types/constants';
 import { GetEventBridgeHandlerOptions } from 'contracts/eventBridge/features';
 import { ServerlessContract } from 'types';
+
+import {
+  GetSQSHandlerOptions,
+  SqsMessageAttributesType,
+  SqsMessageBodyType,
+} from '../contracts/SQS/types';
 
 type GetHandlerOptions<Contract extends ServerlessContract> =
   Contract extends GenericApiGatewayContract
@@ -77,6 +87,20 @@ export function getHandler<
   handler: SwarmionEventBridgeHandler<EventType, Payload, AdditionalArgs>,
 ) => EventBridgeHandler<EventType, Payload, AdditionalArgs>;
 
+/**
+ * must match the type of getSQSHandler
+ */
+export function getHandler<
+  Contract extends SQSContract,
+  MessageBody = SqsMessageBodyType<Contract>,
+  MessageAttributes = SqsMessageAttributesType<Contract>,
+>(
+  contract: Contract,
+  options: GetSQSHandlerOptions,
+): <AdditionalArgs extends unknown[]>(
+  handler: SwarmionSQSHandler<MessageBody, MessageAttributes, AdditionalArgs>,
+) => SQSHandler<AdditionalArgs>;
+
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function getHandler<Contract extends ServerlessContract>(
   contract: Contract,
@@ -94,7 +118,7 @@ export function getHandler<Contract extends ServerlessContract>(
         options as GetApiGatewayHandlerOptions,
       );
     case 'SQS':
-      throw new Error('SQS contract handler is not implemented yet');
+      return getSQSHandler(contract, options as GetSQSHandlerOptions);
     case 'cloudFormation':
       throw new Error('CloudFormation contract has no handler');
     default:

--- a/packages/serverless-contracts/src/features/lambdaTrigger.ts
+++ b/packages/serverless-contracts/src/features/lambdaTrigger.ts
@@ -38,6 +38,11 @@ export function getTrigger<Contract extends ServerlessContract>(
       // @ts-ignore inference is not good enough here, overriding
       return getEventBridgeTrigger(contract, additionalConfig);
 
+    case 'SQS':
+      throw new Error(
+        'SQS contract has no trigger. The trigger only need the SQS arn which is independent of the Contract',
+      );
+
     case 'cloudFormation':
       throw new Error('CloudFormation contract has no trigger');
 

--- a/packages/serverless-contracts/src/types/__tests__/constrainedJSONSchema.type.test.ts
+++ b/packages/serverless-contracts/src/types/__tests__/constrainedJSONSchema.type.test.ts
@@ -21,7 +21,7 @@ typeAssert<A.Extends<typeof simpleSchema, StringDictionaryJSONSchema>>();
 
 const composedSchema = {
   type: 'object',
-  oneof: [
+  oneOf: [
     {
       type: 'object',
       properties: {

--- a/packages/serverless-contracts/src/types/__tests__/constrainedJSONSchema.type.test.ts
+++ b/packages/serverless-contracts/src/types/__tests__/constrainedJSONSchema.type.test.ts
@@ -3,9 +3,9 @@ import { A } from 'ts-toolbelt';
 
 import { typeAssert } from 'utils';
 
-import { ConstrainedJSONSchema } from '../constrainedJSONSchema';
+import { StringDictionaryJSONSchema } from '../constrainedJSONSchema';
 
-type ExtendJsonSchemaCheck = A.Extends<ConstrainedJSONSchema, JSONSchema>;
+type ExtendJsonSchemaCheck = A.Extends<StringDictionaryJSONSchema, JSONSchema>;
 
 const extendJsonSchemaCheck: ExtendJsonSchemaCheck = 1;
 extendJsonSchemaCheck;
@@ -17,7 +17,7 @@ const simpleSchema = {
   additionalProperties: false,
 } as const;
 
-typeAssert<A.Extends<typeof simpleSchema, ConstrainedJSONSchema>>();
+typeAssert<A.Extends<typeof simpleSchema, StringDictionaryJSONSchema>>();
 
 const composedSchema = {
   type: 'object',
@@ -40,4 +40,4 @@ const composedSchema = {
   ],
 } as const;
 
-typeAssert<A.Extends<typeof composedSchema, ConstrainedJSONSchema>>();
+typeAssert<A.Extends<typeof composedSchema, StringDictionaryJSONSchema>>();

--- a/packages/serverless-contracts/src/types/__tests__/constrainedJSONSchema.type.test.ts
+++ b/packages/serverless-contracts/src/types/__tests__/constrainedJSONSchema.type.test.ts
@@ -1,9 +1,12 @@
 import { JSONSchema } from 'json-schema-to-ts';
-import { A } from 'ts-toolbelt';
+import { A, Boolean } from 'ts-toolbelt';
 
 import { typeAssert } from 'utils';
 
-import { StringDictionaryJSONSchema } from '../constrainedJSONSchema';
+import {
+  StringDictionaryJSONSchema,
+  StringOrNumberDictionaryJSONSchema,
+} from '../constrainedJSONSchema';
 
 type ExtendJsonSchemaCheck = A.Extends<StringDictionaryJSONSchema, JSONSchema>;
 
@@ -18,6 +21,9 @@ const simpleSchema = {
 } as const;
 
 typeAssert<A.Extends<typeof simpleSchema, StringDictionaryJSONSchema>>();
+typeAssert<
+  A.Extends<typeof simpleSchema, StringOrNumberDictionaryJSONSchema>
+>();
 
 const composedSchema = {
   type: 'object',
@@ -41,3 +47,56 @@ const composedSchema = {
 } as const;
 
 typeAssert<A.Extends<typeof composedSchema, StringDictionaryJSONSchema>>();
+typeAssert<
+  A.Extends<typeof composedSchema, StringOrNumberDictionaryJSONSchema>
+>();
+
+const numberDictSchema = {
+  type: 'object',
+  properties: { userId: { type: 'number' }, pageNumber: { type: 'number' } },
+  required: ['userId', 'pageNumber'],
+  additionalProperties: false,
+} as const;
+
+typeAssert<
+  Boolean.Not<A.Extends<typeof numberDictSchema, StringDictionaryJSONSchema>>
+>();
+typeAssert<
+  A.Extends<typeof numberDictSchema, StringOrNumberDictionaryJSONSchema>
+>();
+
+const composedNumberAndStringDictSchema = {
+  type: 'object',
+  oneOf: [
+    {
+      type: 'object',
+      properties: {
+        foo: { type: 'number' },
+      },
+      required: ['foo'],
+    },
+    {
+      type: 'object',
+      properties: {
+        bar: { type: 'string' },
+      },
+      required: ['bar'],
+      additonalProperties: false,
+    },
+  ],
+} as const;
+
+typeAssert<
+  Boolean.Not<
+    A.Extends<
+      typeof composedNumberAndStringDictSchema,
+      StringDictionaryJSONSchema
+    >
+  >
+>();
+typeAssert<
+  A.Extends<
+    typeof composedNumberAndStringDictSchema,
+    StringOrNumberDictionaryJSONSchema
+  >
+>();

--- a/packages/serverless-contracts/src/types/constrainedJSONSchema.ts
+++ b/packages/serverless-contracts/src/types/constrainedJSONSchema.ts
@@ -1,4 +1,4 @@
-interface ConstrainedJSONSchemaProperty {
+interface StringDictionaryJSONSchemaProperty {
   readonly type?: 'string';
   readonly const?: string;
   readonly enum?: readonly string[];
@@ -10,15 +10,15 @@ interface ConstrainedJSONSchemaProperty {
  * to only contain string attributes. This is especially useful for path parameters, headers
  * and query parameters that will be stringified anyway.
  */
-export interface ConstrainedJSONSchema {
+export interface StringDictionaryJSONSchema {
   readonly type: 'object';
   readonly additionalProperties?: boolean;
   readonly properties?: {
-    readonly [key: string]: ConstrainedJSONSchemaProperty;
+    readonly [key: string]: StringDictionaryJSONSchemaProperty;
   };
   readonly required?: readonly string[];
   readonly [key: string]: unknown;
-  readonly oneOf?: readonly ConstrainedJSONSchema[];
-  readonly anyOf?: readonly ConstrainedJSONSchema[];
-  readonly allOf?: readonly ConstrainedJSONSchema[];
+  readonly oneOf?: readonly StringDictionaryJSONSchema[];
+  readonly anyOf?: readonly StringDictionaryJSONSchema[];
+  readonly allOf?: readonly StringDictionaryJSONSchema[];
 }

--- a/packages/serverless-contracts/src/types/constrainedJSONSchema.ts
+++ b/packages/serverless-contracts/src/types/constrainedJSONSchema.ts
@@ -5,6 +5,13 @@ interface StringDictionaryJSONSchemaProperty {
   readonly [key: string]: unknown;
 }
 
+interface StringOrNumberDictionaryJSONSchemaProperty {
+  readonly type?: 'string' | 'number';
+  readonly const?: string | number;
+  readonly enum?: readonly (string | number)[];
+  readonly [key: string]: unknown;
+}
+
 /**
  * A simplified version of the JSONSchema definition in order to constrain some definitions
  * to only contain string attributes. This is especially useful for path parameters, headers
@@ -21,4 +28,21 @@ export interface StringDictionaryJSONSchema {
   readonly oneOf?: readonly StringDictionaryJSONSchema[];
   readonly anyOf?: readonly StringDictionaryJSONSchema[];
   readonly allOf?: readonly StringDictionaryJSONSchema[];
+}
+
+/**
+ * A simplified version of the JSONSchema definition in order to constrain some definitions
+ * to only contain string or number attributes. This is especially useful for SQS message attributes
+ */
+export interface StringOrNumberDictionaryJSONSchema {
+  readonly type: 'object';
+  readonly additionalProperties?: boolean;
+  readonly properties?: {
+    readonly [key: string]: StringOrNumberDictionaryJSONSchemaProperty;
+  };
+  readonly required?: readonly string[];
+  readonly [key: string]: unknown;
+  readonly oneOf?: readonly StringOrNumberDictionaryJSONSchema[];
+  readonly anyOf?: readonly StringOrNumberDictionaryJSONSchema[];
+  readonly allOf?: readonly StringOrNumberDictionaryJSONSchema[];
 }

--- a/packages/serverless-contracts/src/types/serverlessContract.ts
+++ b/packages/serverless-contracts/src/types/serverlessContract.ts
@@ -2,9 +2,11 @@ import {
   CloudFormationContract,
   EventBridgeContract,
   GenericApiGatewayContract,
+  SQSContract,
 } from 'contracts';
 
 export type ServerlessContract =
   | GenericApiGatewayContract
   | CloudFormationContract
-  | EventBridgeContract;
+  | EventBridgeContract
+  | SQSContract;

--- a/packages/serverless-contracts/vitest.config.ts
+++ b/packages/serverless-contracts/vitest.config.ts
@@ -5,6 +5,7 @@ import { configDefaults, defineConfig } from 'vitest/config';
 export default defineConfig({
   plugins: [tsconfigPaths(), codspeedPlugin()],
   test: {
+    mockReset: true,
     coverage: { reporter: ['text-summary', 'lcovonly'] },
     globals: true,
     exclude: [...configDefaults.exclude, '**/*.type.test.ts'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,9 @@ importers:
       '@aws-sdk/client-eventbridge':
         specifier: ^3.540.0
         version: 3.540.0
+      '@aws-sdk/client-sqs':
+        specifier: ^3.540.0
+        version: 3.549.0
       '@swarmion/serverless-helpers':
         specifier: ^0.31.3
         version: link:../serverless-helpers
@@ -1334,6 +1337,56 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/client-sqs@3.549.0:
+    resolution: {integrity: sha512-3nLGiHQrnSD5I5hdjykOLZpEwodePs6lZMnS6ltQWcJ+arwjCPRwApMgDcRpKFHksV78AcvIwly41y37IbpekA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.549.0(@aws-sdk/credential-provider-node@3.549.0)
+      '@aws-sdk/core': 3.549.0
+      '@aws-sdk/credential-provider-node': 3.549.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-sdk-sqs': 3.547.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/md5-js': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/client-ssm@3.540.0:
     resolution: {integrity: sha512-GcELCPJBcYpd0zPYO+fTKjeRtvufFEM0AMIdeBojNqObFLx9eyjhzJNpykXulE8J3kPvjzXEs88azPGf0PXu5Q==}
     engines: {node: '>=14.0.0'}
@@ -2136,6 +2189,18 @@ packages:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       '@smithy/util-config-provider': 2.3.0
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/middleware-sdk-sqs@3.547.0:
+    resolution: {integrity: sha512-jxlJmw36QGY2IAwCBFVE3YYdrkO5N3Grio4vGYkGq/gGTzM1EhjghRCS2eVc1wiyavOS+kwChkskRSsBcP6zEg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.535.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-hex-encoding': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     dev: false
 
@@ -6758,6 +6823,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
+
+  /@smithy/md5-js@2.2.0:
+    resolution: {integrity: sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==}
+    dependencies:
+      '@smithy/types': 2.12.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    dev: false
 
   /@smithy/middleware-content-length@2.2.0:
     resolution: {integrity: sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,7 +251,7 @@ importers:
   packages/integration-tests:
     dependencies:
       '@aws-sdk/client-ssm':
-        specifier: ^3.470.0
+        specifier: ^3.540.0
         version: 3.540.0
       '@babel/traverse':
         specifier: ^7.23.6
@@ -501,7 +501,7 @@ importers:
   packages/serverless-contracts:
     dependencies:
       '@aws-sdk/client-eventbridge':
-        specifier: ^3.470.0
+        specifier: ^3.540.0
         version: 3.540.0
       '@swarmion/serverless-helpers':
         specifier: ^0.31.3
@@ -760,16 +760,16 @@ importers:
   services/orchestrator:
     dependencies:
       '@aws-sdk/client-dynamodb':
-        specifier: ^3.470.0
+        specifier: ^3.540.0
         version: 3.540.0
       '@aws-sdk/client-eventbridge':
-        specifier: ^3.470.0
+        specifier: ^3.540.0
         version: 3.540.0
       '@aws-sdk/lib-dynamodb':
-        specifier: ^3.470.0
+        specifier: ^3.540.0
         version: 3.540.0(@aws-sdk/client-dynamodb@3.540.0)
       '@aws-sdk/util-dynamodb':
-        specifier: ^3.470.0
+        specifier: ^3.540.0
         version: 3.540.0(@aws-sdk/client-dynamodb@3.540.0)
       '@swarmion/orchestrator-contracts':
         specifier: ^0.31.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,9 @@ importers:
       ts-toolbelt:
         specifier: ^9.6.0
         version: 9.6.0
+      ulid:
+        specifier: ^2.3.0
+        version: 2.3.0
     devDependencies:
       '@codspeed/vitest-plugin':
         specifier: 3.1.0

--- a/services/orchestrator/package.json
+++ b/services/orchestrator/package.json
@@ -23,10 +23,10 @@
     "test-unit": "vitest run --coverage --passWithNoTests"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.470.0",
-    "@aws-sdk/client-eventbridge": "^3.470.0",
-    "@aws-sdk/lib-dynamodb": "^3.470.0",
-    "@aws-sdk/util-dynamodb": "^3.470.0",
+    "@aws-sdk/client-dynamodb": "^3.540.0",
+    "@aws-sdk/client-eventbridge": "^3.540.0",
+    "@aws-sdk/lib-dynamodb": "^3.540.0",
+    "@aws-sdk/util-dynamodb": "^3.540.0",
     "@swarmion/orchestrator-contracts": "^0.31.3",
     "@swarmion/serverless-cdk-plugin": "^0.31.3",
     "@swarmion/serverless-configuration": "^0.31.3",

--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/1-api-gateway.md
@@ -636,7 +636,7 @@ paths:
 ```
 
 :::tip
-If you use the [serverless-contracts-plugin](./5-serverless-plugin.md) for the Serverlesss framework, this feature is used by the `pnpm serverless generateOpenApiDocumentation` command with the contract that your service provides.
+If you use the [serverless-contracts-plugin](./6-serverless-plugin.md) for the Serverlesss framework, this feature is used by the `pnpm serverless generateOpenApiDocumentation` command with the contract that your service provides.
 :::
 
 ## Consumer-side usage

--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/3-sqs.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/3-sqs.md
@@ -1,0 +1,357 @@
+---
+sidebar_position: 2
+---
+
+# Use SQS contracts
+
+Amazon Simple Queue Service (SQS) is a fully managed message queuing service that enables you to decouple and scale microservices, distributed systems, and serverless applications.
+
+_Emitters_ publishes messages into a **Queue**.
+_Consumers_ polls batch of messages from the queue to process them.
+
+An SQS contract can be defined between _emitters_ and _consumers_ ensuring the stability of their interaction.
+It defines common message properties such as the body schema assuring that messages published by _emitters_ can be handled by _consumers_'.
+
+## Defining an SQS contract
+
+Let's create our first SQS contract. The following arguments are needed:
+
+- the `id` serves to uniquely identify the contract among all stacks.
+  Please note that this id MUST be unique among all stacks. Use a convention to ensure uniqueness
+- the `messageBodySchema` is a JSON schema representing the message body format. In order to properly use Typescript's type inference, it **MUST** be created using the `as const` directive. For more information, see [json-schema-to-ts](https://github.com/ThomasAribart/json-schema-to-ts#fromschema)
+- the `messageAttributesSchema` is an _optional_ JSON schema representing the message attributes format.
+
+```ts
+import { SQSContract } from '@swarmion/serverless-contracts';
+import { JSONSchema } from 'json-schema-to-ts';
+
+export const messageBodySchema = {
+  type: 'object',
+  properties: {
+    toto: { type: 'string' },
+  },
+  required: ['toto'],
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+export const mySqsContract = new SQSContract({
+  id: 'mySQSContract',
+  messageBodySchema,
+});
+```
+
+## Consumer-side usage
+
+In an AWS serverless application, messages _consumers_ would typically be lambda functions.
+Here is how to trigger a lambda when an event respecting an EventBridgeEvent Contract has been published.
+
+### Generate the lambda trigger
+
+The SQS contract is not needed to define the trigger of the consumer.
+It only depends on the SQS ARN, which is not in the contract.
+
+However, you must set [the function response type to `ReportBatchItemFailures`](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting) to be compatible with the default behavior of the Swarmion handler defined in the next part.
+
+With serverless framework, the function definition should be like:
+
+```ts
+export default {
+  environment: {},
+  handler: getHandlerPath(__dirname),
+  events: [
+    {
+      sqs: {
+        arn: 'myQueueArn',
+        functionResponseType: 'ReportBatchItemFailures',
+      },
+    },
+  ],
+};
+```
+
+With CDK, the function definition should be like:
+
+```ts
+const myLambda = new NodejsFunction(this, 'myLambda', {
+  entry: path.join(__dirname, 'handler.ts'),
+  handler: 'main',
+});
+myLambda.addEventSource(
+  new SqsEventSource(myQueue, {
+    reportBatchItemFailures: true,
+  }),
+);
+```
+
+The lambda will be triggered with a batch of up to 10 messages when messages are available in the queue.
+
+### Generate the lambda handler
+
+With SQS contracts, you can generate a natively typed lambda handler which
+
+- **validates** the messages against the contract to unsure the message body and message attributes format
+- **parse** the message body and message attributes to handle proper js objects.
+- abstract the iteration on the **batched messages**
+- abstract the return of **failed messages** to SQS
+
+Simply write:
+
+```ts
+import { getHandler } from '@swarmion/serverless-contracts';
+import { ajv } from 'libs/ajv';
+
+export const main = getHandler(mySqsContract, { ajv })(async message => {
+  const { toto } = message.body; // parsed and typed with the correct keys
+
+  // write your business logic for one message
+});
+```
+
+:::info
+If one of the message handlers fails,
+**the global handler will catch the error** and return the id of the failed messages to SQS.
+The return of the handler will be like:
+
+```json
+{
+  "batchItemFailures": [
+    {
+      "itemIdentifier": "messageId"
+    }
+  ]
+}
+```
+
+:::
+
+:::info
+The default body parser is `JSON.parse`. You can provide your own body parser with the `bodyParser` option.
+Use explicit `undefined` to disable body parsing.
+
+```ts
+import { getHandler } from '@swarmion/serverless-contracts';
+
+const handler = getHandler(myContract, {
+  ajv,
+  bodyParser: undefined,
+})(async message => {
+  const { body } = message; // body is a raw string
+  // ...
+});
+```
+
+:::
+
+:::info
+Regarding the `ajv` option, we advise you to use a singleton instance of ajv that you define in a separate file. This way, you can use the same instance for all your contracts and middlewares.
+
+[See an example](../../how-to-guides/migration-guides/ajv-dependency-injection#share-a-singleton-ajv-instance-across-the-whole-project)
+:::
+
+:::caution
+This handler also provides a body validation
+that will throw an error if there is a mismatch with the `messageBodySchema`.
+This ensures that invalid messages will not be mistakenly taken into account.
+However, be sure to set up an invalid message failure flow,
+for example, with a [DLQ](https://www.serverless.com/blog/lambda-destinations/).
+
+If you still wish to disable this behavior, you can use the optional second argument in the `getHandler` feature.
+If you do so, you can omit the `ajv` option.
+
+```ts
+import { getHandler } from '@swarmion/serverless-contracts';
+
+const handler = getHandler(myContract, {
+  validateBody: false,
+})(async message => {
+  // ...
+});
+```
+
+:::
+
+Alternatively, if you wish to handle the batch behavior by yourself, you can set the `handleBatchedRecords` option to `false`.
+
+```ts
+import { getHandler } from '@swarmion/serverless-contracts';
+import { ajv } from 'libs/ajv';
+
+export const main = getHandler(mySqsContract, {
+  ajv,
+  handleBatchedRecords: false,
+})(async ({ records }) => {
+  records.forEach(message => {
+    const { toto } = message.body; // parsed and typed with the correct keys
+
+    // write your business logic for one message
+  });
+  // Handle message failure as you want.
+  // Be aware that unhandled failure will make the whole batch of messages available after the visibility timeout,
+  // even the processed one.
+});
+```
+
+## Emitter-side usage
+
+Now that we have generated a type-safe Lambda triggered by our messages, let's see how to publish messages from the _emitter_.
+
+### Build a typed sendMessage function
+
+The builder function `buildSendMessage` returns a fully type-safe async function you can call to send a message.
+
+In order to optimize Lambda cold starts, instantiating the SQS sdk must be avoided inside the Lambda handler. This is why we provide a builder function to call outside the Lambda handler.
+
+```ts
+import { buildSendMessage, getHandler } from '@swarmion/serverless-contracts';
+import { getEnvVariable } from '@swarmion/serverless-helpers';
+import { SQSClient } from '@aws-sdk/client-sqs';
+import { ajv } from 'libs/ajv';
+
+// Instantiate the sdk
+const sqsClient = new SQSClient({});
+
+// The queue url is here available in an env variable, but you can adapt this
+const queueUrl = getEnvVariable('QUEUE_URL');
+
+const sendMyMessage = buildSendMessage(mySqsContract, {
+  queueUrl,
+  sqsClient,
+  ajv,
+});
+
+export const main = getHandler(anotherContract, { ajv })(async event => {
+  await sendMyMessage({ body: { toto: 'totoValue' } }); // Typesafe
+
+  // rest of the lambda
+});
+```
+
+:::info
+The default body serializer is `JSON.serialize`. You can provide your own body serializer with the `bodySerializer` option.
+Use explicit `undefined` to disable body serialization.
+
+```ts
+const sendMyMessage = buildSendMessage(mySqsContract, {
+  queueUrl,
+  sqsClient,
+  ajv,
+  bodySerializer: undefined,
+});
+
+await sendMyMessage({ body: 'toto' });
+```
+
+:::
+
+:::info
+Regarding the `ajv` option, we advise you to use a singleton instance of ajv that you define in a separate file. This way, you can use the same instance for all your contracts and middlewares.
+
+[See an example](../../how-to-guides/migration-guides/ajv-dependency-injection#share-a-singleton-ajv-instance-across-the-whole-project)
+:::
+
+:::caution
+The message sender also provides a body validation
+that will throw an error if there is a mismatch with the `messageBodySchema`.
+This ensures that invalid messages will not be mistakenly sent.
+
+If you still wish to disable this behavior, you can use the optional `validateMessage` argument in the `buildSendMessage` feature.
+If you do so, you can omit the `ajv` option.
+
+```ts
+const sendMyMessage = buildSendMessage(mySqsContract, {
+  queueUrl,
+  sqsClient,
+  validateMessage: false,
+});
+
+await sendMyMessage({ body: { what: 'ever' } });
+```
+
+:::
+
+:::caution
+This only works with the AWS SDK v3
+:::
+
+### Build a typed sendMessages function
+
+The builder function `buildSendMessages` returns a fully type-safe async function you can call to send a list of messages
+to the SQS queue without bothering with the batching process or retry policy in case of throttling.
+
+```ts
+import { buildSendMessages, getHandler } from '@swarmion/serverless-contracts';
+import { getEnvVariable } from '@swarmion/serverless-helpers';
+import { SQSClient } from '@aws-sdk/client-sqs';
+import { ajv } from 'libs/ajv';
+
+// Instantiate the sdk
+const sqsClient = new SQSClient({});
+
+// The queue url is here available in an env variable, but you can adapt this
+const queueUrl = getEnvVariable('QUEUE_URL');
+
+const sendMyMessage = buildSendMessages(mySqsContract, {
+  queueUrl,
+  sqsClient,
+  ajv,
+});
+
+export const main = getHandler(anotherContract, { ajv })(async event => {
+  await sendMyMessages([
+    { body: { toto: 'totoValue1' } }, // Typesafe
+    { body: { toto: 'totoValue2' } },
+    { body: { toto: 'totoValue3' } },
+    { body: { toto: 'totoValue4' } },
+    { body: { toto: 'totoValue5' } },
+  ]);
+
+  // rest of the lambda
+});
+```
+
+:::info
+It supports the same options as `buildSendMessage` plus `maxRetries` and `baseDelay` to configure the behavior in case of SendMessageBatchCommand throttling.
+:::
+
+:::caution
+If the `maxRetries` is reached, the message sender will throw by default. You can set the `throwOnFailedBatch` option to `false` to return the failed items instead
+:::
+
+## Use message attributes
+
+The contract and all its utils also support [SQS message attributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-java-send-message-with-attributes.html).
+If you define a `messageAttributesSchema` in the contract,
+the message attributes from the incoming messages will be parsed and validated,
+the message attributes of messages to be sent will be validated and serialized.
+
+:::info
+[Message attributes format in SQS messages](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html) is very specific.
+
+For example, for a string attribute,
+the SQS message will contain the following `MessagesAttributes` object:
+
+```json
+{
+  "attributeName": {
+    "DataType": "String",
+    "StringValue": "attributeValue"
+  }
+}
+```
+
+The parsing function parses it into:
+
+```json
+{
+  "attributeName": "attributeValue"
+}
+```
+
+and the serialization does the opposite based on the json schema provided.
+:::
+
+:::caution
+
+Only string and number data types are currently supported for serialization.
+
+:::

--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/4-additional-args.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/4-additional-args.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Pass additional arguments to Lambda handlers

--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/5-cloudformation.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/5-cloudformation.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Use CloudFormation contracts

--- a/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/6-serverless-plugin.md
+++ b/user-docs/documentation/docs/how-to-guides/1-use-serverless-contracts/6-serverless-plugin.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Serverless Plugin


### PR DESCRIPTION
# SQS Contract

SQS is not easy to use. Messages are serialized and batched. This contract aims to simplify the usage of SQS. It abstracts serialization and deserialization of the messages while providing type safety at runtime and in the IDE. It also abstracts technical batching process to write or read list of messages.

## Features

- `getSendMessage`: returns a function that **validates**, **serializes** and **send** a single message through SQS
- `getSendMessages`: returns a function that **validates**, **serializes**, **batches** and **send** a list of messages through SQS. Handle **retry** if the SQS is throttled because there are too many messages
- `getHandler`: returns a type safe lambda handler that **deserializes**, **validates**, **handle batched messages one by one** and **properly inform SQS of failed messages**. The callback (internal handler) receives one message and will be called in parallel for each message of the batch. If it throws, the lambda will not throw and only its message will be retuned to the SQS.
- `getLambdaHandler` (naming is bad, but is the same as AGW contract): returns a type safe lambda handler that **deserializes** and **validates** messages. The callback (internal handler) receives the whole batch of messages and is free to process them as it wants.

## TODO before merge

- [x] Publish alpha: https://www.npmjs.com/package/@swarmion/serverless-contracts/v/0.32.0-alpha.0
- [ ] e2e test the alpha on some projects
- [x] Add documentation: https://docs-preview-996--swarmion.netlify.app/docs/how-to-guides/use-serverless-contracts/sqs/