### PR TITLE
feat(nx-plugin): use current workspace dependency versions instead of latest

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,4 @@ nx-cache
 .docusaurus
 testEnvVarsCache.json
 .nx
+.all-contributorsrc

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 </p>
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-24-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 A set of tools to build and deploy type-safe microservices. In order to see working examples of these tools, check out the [examples folder](https://github.com/swarmion/swarmion/tree/main/examples).

--- a/packages/nx-plugin/src/generators/cdk-service/typed-json-config/package.json.ts
+++ b/packages/nx-plugin/src/generators/cdk-service/typed-json-config/package.json.ts
@@ -1,12 +1,6 @@
 import { joinPathFragments } from '@nx/devkit';
 
-import {
-  getWorkspaceDependencyVersion,
-  typescriptVersion,
-  vitestCoverageC8Version,
-  vitestVersion,
-  viteTsConfigPathsVersion,
-} from 'generators/helpers';
+import { getWorkspaceDependencyVersion } from 'generators/helpers';
 
 import { NormalizedSchema, PackageJson } from '../../types';
 
@@ -48,21 +42,20 @@ export const packageJson = (options: NormalizedSchema): PackageJson => ({
     '@middy/http-cors': '^4.7.0',
     '@swarmion/serverless-contracts': 'latest',
     '@swarmion/serverless-helpers': 'latest',
-    ajv: 'latest',
+    ajv: getWorkspaceDependencyVersion('ajv'),
   },
   devDependencies: {
-    '@types/node': 'latest',
-    '@vitest/coverage-v8': vitestCoverageC8Version,
-    'aws-cdk': getWorkspaceDependencyVersion('aws-cdk-lib'),
+    '@types/node': getWorkspaceDependencyVersion('@types/node'),
+    '@vitest/coverage-v8': getWorkspaceDependencyVersion('@vitest/coverage-v8'),
     'aws-cdk-lib': getWorkspaceDependencyVersion('aws-cdk-lib'),
     constructs: getWorkspaceDependencyVersion('constructs'),
-    'dependency-cruiser': 'latest',
-    esbuild: 'latest',
-    eslint: 'latest',
-    prettier: 'latest',
-    'ts-node': 'latest',
-    typescript: typescriptVersion,
-    'vite-tsconfig-paths': viteTsConfigPathsVersion,
-    vitest: vitestVersion,
+    'dependency-cruiser': getWorkspaceDependencyVersion('dependency-cruiser'),
+    esbuild: getWorkspaceDependencyVersion('esbuild'),
+    eslint: getWorkspaceDependencyVersion('eslint'),
+    prettier: getWorkspaceDependencyVersion('prettier'),
+    'ts-node': getWorkspaceDependencyVersion('ts-node'),
+    typescript: getWorkspaceDependencyVersion('typescript'),
+    'vite-tsconfig-paths': getWorkspaceDependencyVersion('vite-tsconfig-paths'),
+    vitest: getWorkspaceDependencyVersion('vitest'),
   },
 });

--- a/packages/nx-plugin/src/generators/helpers/getWorkspaceDependencyVersion.ts
+++ b/packages/nx-plugin/src/generators/helpers/getWorkspaceDependencyVersion.ts
@@ -4,19 +4,25 @@ type PackageDescription = {
   name: string;
   version: string;
   dependencies?: Record<string, PackageDescription>;
+  devDependencies?: Record<string, PackageDescription>;
 };
 
 export const getWorkspaceDependencyVersion = (
   dependencyName: string,
 ): string => {
   const packages = JSON.parse(
-    execSync(`pnpm why -rP --json ${dependencyName}`).toString(),
+    execSync(`pnpm why -r --json --depth 1 ${dependencyName}`).toString(),
   ) as PackageDescription[];
 
-  return (
-    packages
-      .filter(({ dependencies }) => dependencies !== undefined)
-      .map(({ dependencies = {} }) => dependencies[dependencyName])[0]
-      ?.version ?? 'latest'
+  const resolvedPackage = packages.find(
+    ({ dependencies, devDependencies }) =>
+      dependencies !== undefined || devDependencies !== undefined,
   );
+
+  const version =
+    resolvedPackage?.dependencies?.[dependencyName]?.version ??
+    resolvedPackage?.devDependencies?.[dependencyName]?.version ??
+    'latest';
+
+  return version;
 };

--- a/packages/nx-plugin/src/generators/helpers/index.ts
+++ b/packages/nx-plugin/src/generators/helpers/index.ts
@@ -6,4 +6,3 @@ export * from './updateCodeWorkspace';
 export * from './updatePackages';
 export * from './updatePnpmWorkspaces';
 export * from './updateRootTsConfig';
-export * from './versions';

--- a/packages/nx-plugin/src/generators/helpers/versions.ts
+++ b/packages/nx-plugin/src/generators/helpers/versions.ts
@@ -1,7 +1,0 @@
-// typescript
-export const typescriptVersion = '^5.0.0';
-
-// vitest
-export const vitestVersion = '^0.34.6';
-export const viteTsConfigPathsVersion = '^4.2.0';
-export const vitestCoverageC8Version = '^0.34.6';

--- a/packages/nx-plugin/src/generators/library/typed-json-config/package.json.ts
+++ b/packages/nx-plugin/src/generators/library/typed-json-config/package.json.ts
@@ -1,11 +1,6 @@
 import { joinPathFragments } from '@nx/devkit';
 
-import {
-  typescriptVersion,
-  vitestCoverageC8Version,
-  vitestVersion,
-  viteTsConfigPathsVersion,
-} from 'generators/helpers';
+import { getWorkspaceDependencyVersion } from 'generators/helpers';
 
 import { NormalizedSchema, PackageJson } from '../../types';
 
@@ -46,19 +41,19 @@ export const packageJson = (options: NormalizedSchema): PackageJson => ({
     watch: "pnpm clean dist && concurrently 'pnpm:package-* --watch'",
   },
   devDependencies: {
-    '@types/node': 'latest',
-    '@vitest/coverage-v8': vitestCoverageC8Version,
-    concurrently: 'latest',
-    'dependency-cruiser': 'latest',
-    eslint: 'latest',
-    'json-schema-to-ts': 'latest',
-    prettier: 'latest',
-    rimraf: 'latest',
-    'ts-node': 'latest',
-    'tsc-alias': 'latest',
-    tsup: 'latest',
-    typescript: typescriptVersion,
-    'vite-tsconfig-paths': viteTsConfigPathsVersion,
-    vitest: vitestVersion,
+    '@types/node': getWorkspaceDependencyVersion('@types/node'),
+    '@vitest/coverage-v8': getWorkspaceDependencyVersion('@vitest/coverage-v8'),
+    concurrently: getWorkspaceDependencyVersion('concurrently'),
+    'dependency-cruiser': getWorkspaceDependencyVersion('dependency-cruiser'),
+    eslint: getWorkspaceDependencyVersion('eslint'),
+    'json-schema-to-ts': getWorkspaceDependencyVersion('json-schema-to-ts'),
+    prettier: getWorkspaceDependencyVersion('prettier'),
+    rimraf: getWorkspaceDependencyVersion('rimraf'),
+    'ts-node': getWorkspaceDependencyVersion('ts-node'),
+    'tsc-alias': getWorkspaceDependencyVersion('tsc-alias'),
+    tsup: getWorkspaceDependencyVersion('tsup'),
+    typescript: getWorkspaceDependencyVersion('typescript'),
+    'vite-tsconfig-paths': getWorkspaceDependencyVersion('vite-tsconfig-paths'),
+    vitest: getWorkspaceDependencyVersion('vitest'),
   },
 });

--- a/packages/nx-plugin/src/generators/service/typed-json-config/package.json.ts
+++ b/packages/nx-plugin/src/generators/service/typed-json-config/package.json.ts
@@ -1,11 +1,6 @@
 import { joinPathFragments } from '@nx/devkit';
 
-import {
-  typescriptVersion,
-  vitestCoverageC8Version,
-  vitestVersion,
-  viteTsConfigPathsVersion,
-} from 'generators/helpers';
+import { getWorkspaceDependencyVersion } from 'generators/helpers';
 
 import { NormalizedSchema, PackageJson } from '../../types';
 
@@ -43,19 +38,25 @@ export const packageJson = (options: NormalizedSchema): PackageJson => ({
     '@swarmion/serverless-helpers': 'latest',
   },
   devDependencies: {
-    '@serverless/typescript': 'latest',
-    '@types/node': 'latest',
-    '@vitest/coverage-v8': vitestCoverageC8Version,
-    'dependency-cruiser': 'latest',
-    esbuild: 'latest',
-    eslint: 'latest',
-    serverless: 'latest',
-    'serverless-custom-iam-roles-per-function': 'latest',
-    'serverless-esbuild': 'latest',
-    'serverless-iam-roles-per-function': 'latest',
-    'ts-node': 'latest',
-    typescript: typescriptVersion,
-    'vite-tsconfig-paths': viteTsConfigPathsVersion,
-    vitest: vitestVersion,
+    '@serverless/typescript': getWorkspaceDependencyVersion(
+      '@serverless/typescript',
+    ),
+    '@types/node': getWorkspaceDependencyVersion('@types/node'),
+    '@vitest/coverage-v8': getWorkspaceDependencyVersion('@vitest/coverage-v8'),
+    'dependency-cruiser': getWorkspaceDependencyVersion('dependency-cruiser'),
+    esbuild: getWorkspaceDependencyVersion('esbuild'),
+    eslint: getWorkspaceDependencyVersion('eslint'),
+    serverless: getWorkspaceDependencyVersion('serverless'),
+    'serverless-custom-iam-roles-per-function': getWorkspaceDependencyVersion(
+      'serverless-custom-iam-roles-per-function',
+    ),
+    'serverless-esbuild': getWorkspaceDependencyVersion('serverless-esbuild'),
+    'serverless-iam-roles-per-function': getWorkspaceDependencyVersion(
+      'serverless-iam-roles-per-function',
+    ),
+    'ts-node': getWorkspaceDependencyVersion('ts-node'),
+    typescript: getWorkspaceDependencyVersion('typescript'),
+    'vite-tsconfig-paths': getWorkspaceDependencyVersion('vite-tsconfig-paths'),
+    vitest: getWorkspaceDependencyVersion('vitest'),
   },
 });

--- a/scripts/check-example.sh
+++ b/scripts/check-example.sh
@@ -6,8 +6,8 @@ set -e
 # For this, we need to have the local version of Swarmion packages (not the ones published on npm)
 # This is why we need to symlink packages with the swarmion_setup function
 
-pnpm nx run create-swarmion-app:build
-pnpm package
+pnpm nx run create-swarmion-app:build --skip-nx-cache # important to skip cache here
+pnpm package --skip-nx-cache                          # important to skip cache here
 
 BASE_DIR=$(pwd)
 TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
This improves the way new package versions are generated by the plugin. We used to have `latest` by default, which can cause sudden issues when a new major version is released and we are not ready (for example, eslint v9 requires some config rework, and we can't push it directly if the rest of the repo is not migrated.
In this new version, we resolve the current version of the package and only fallback on `latest` if we found no match.

This will also unblock all PRs currently blocked by the merge train 🙃 