### PR TITLE
Fix/p-queue error

### DIFF
--- a/packages/serverless-contracts/package.json
+++ b/packages/serverless-contracts/package.json
@@ -48,7 +48,7 @@
     "json-schema-to-ts": "3.1.1",
     "lodash": "^4.17.21",
     "openapi-types": "12.1.3",
-    "p-queue-compat": "^1.0.226",
+    "p-queue": "^6.6.2",
     "path-to-regexp": "^8.0.0",
     "seedrandom": "^3.0.5",
     "ts-toolbelt": "^9.6.0",

--- a/packages/serverless-contracts/src/contracts/SQS/features/sendMessages.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/sendMessages.ts
@@ -3,8 +3,9 @@ import {
   SendMessageBatchRequestEntry,
 } from '@aws-sdk/client-sqs';
 import { BatchResultErrorEntry } from '@aws-sdk/client-sqs/dist-types/models/models_0';
-import PQueue from 'p-queue';
+import _PQueue from 'p-queue';
 
+import { fixESMInteropIssue } from '../../../utils/fixESMInteropIssue';
 import { SQSContract } from '../sqsContract';
 import { SendMessagesBuilderOptions, SendMessagesSideEffect } from '../types';
 import {
@@ -14,6 +15,7 @@ import {
   validateMessages,
   wait,
 } from '../utils';
+const PQueue = fixESMInteropIssue(_PQueue);
 
 export const InfiniteThroughput = 0;
 

--- a/packages/serverless-contracts/src/contracts/SQS/features/sendMessages.ts
+++ b/packages/serverless-contracts/src/contracts/SQS/features/sendMessages.ts
@@ -3,7 +3,7 @@ import {
   SendMessageBatchRequestEntry,
 } from '@aws-sdk/client-sqs';
 import { BatchResultErrorEntry } from '@aws-sdk/client-sqs/dist-types/models/models_0';
-import PQueue from 'p-queue-compat';
+import PQueue from 'p-queue';
 
 import { SQSContract } from '../sqsContract';
 import { SendMessagesBuilderOptions, SendMessagesSideEffect } from '../types';

--- a/packages/serverless-contracts/src/utils/fixESMInteropIssue.ts
+++ b/packages/serverless-contracts/src/utils/fixESMInteropIssue.ts
@@ -1,0 +1,18 @@
+// Esbuild wrap the require of some dependencies with __toESM
+// Because this lib is of type module, __toESM put the required module into a default attribute
+// https://github.com/egoist/tsup/issues/658
+// https://github.com/evanw/esbuild/issues/2023
+// Some librairie have already made this default export transformation and it causes a double default export which breaks the code.
+// This function is a workaround to fix this issue.
+// Other workarounds are
+// - use splitting option of Tsup wich use splitting feature of esbuild. The __toESM is replace with another interop function which doesn't add another default if it has already be done. But this seems to be a side effect of esbuild splitting which is explicitly not compatible with cjs. => I decided not to use it.
+// - Some libs affect the default export directly to the exports object. The behavior of __toESM doesn't break because it only add one default. => In our cas some library can't be modified because they now are in full ESM and don't support cjs anymore.
+export const fixESMInteropIssue = <T>(object: T): T => {
+  // @ts-expect-error typescript can't knwow that a double default have been added by esbuild through tsup
+  if (object && object.default) {
+    // @ts-expect-error typescript can't knwow that a double default have been added by esbuild through tsup
+    return object.default as T;
+  }
+
+  return object;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,9 +525,9 @@ importers:
       openapi-types:
         specifier: 12.1.3
         version: 12.1.3
-      p-queue-compat:
-        specifier: ^1.0.226
-        version: 1.0.227
+      p-queue:
+        specifier: ^6.6.2
+        version: 6.6.2
       path-to-regexp:
         specifier: ^8.0.0
         version: 8.2.0
@@ -9211,10 +9211,6 @@ packages:
     resolution: {integrity: sha512-08pj8ATpzMR0Y80x50yJHn37NF6vjrqHutASaX5LiH5npS9XPvrUmscd9MF5R4fuYRHOxQR1FfMIlF7AzwoPqw==}
     engines: {node: '>=8'}
 
-  p-queue-compat@1.0.227:
-    resolution: {integrity: sha512-uNKILAU2Wg6oj7hlvcDJgY4Xl1qzqqOEv/Mq8YtA0ApQQxJDa6DQoRElCPMa55mQ/A3jWeT6qSmcwzNI1cFSrA==}
-    engines: {node: '>=12'}
-
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
@@ -9226,10 +9222,6 @@ packages:
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
-
-  p-timeout-compat@1.0.5:
-    resolution: {integrity: sha512-JUyLagABYj4bu58nXmMEO+JpHlimYomLY3xdatcPWKRRVVQ3ky55Ki4Mdj2OUGDfkV2BPt87zqSzISk0ztwruw==}
-    engines: {node: '>=12'}
 
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -23905,11 +23897,6 @@ snapshots:
 
   p-pipe@3.1.0: {}
 
-  p-queue-compat@1.0.227:
-    dependencies:
-      eventemitter3: 5.0.1
-      p-timeout-compat: 1.0.5
-
   p-queue@6.6.2:
     dependencies:
       eventemitter3: 4.0.7
@@ -23921,8 +23908,6 @@ snapshots:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
-
-  p-timeout-compat@1.0.5: {}
 
   p-timeout@3.2.0:
     dependencies:


### PR DESCRIPTION
Fix cjs usage of serverless-contracts. P-Queue weren't compatible with a bundle with esbuild from a type module package

Esbuild wrap the require of some dependencies with __toESM
Because this lib is of type module, __toESM put the required module into a default attribute
https://github.com/egoist/tsup/issues/658
https://github.com/evanw/esbuild/issues/2023
Some librairie have already made this default export transformation and it causes a double default export which breaks the code.
This function is a workaround to fix this issue.
Other workarounds are
- use splitting option of Tsup wich use splitting feature of esbuild. The __toESM is replace with another interop function which doesn't add another default if it has already be done. But this seems to be a side effect of esbuild splitting which is explicitly not compatible with cjs. => I decided not to use it.
- Some libs affect the default export directly to the exports object. The behavior of __toESM doesn't break because it only add one default. => In our case p-queue can't be modified because they now are in full ESM and don't support cjs anymore.
