### PR TITLE
Feat/multiple eventbridge handler

### DIFF
--- a/contracts/orchestrator-contracts/src/contracts/events/index.ts
+++ b/contracts/orchestrator-contracts/src/contracts/events/index.ts
@@ -1,1 +1,2 @@
 export * from './onDeploymentRequested';
+export * from './onDeploymentUpdated';

--- a/contracts/orchestrator-contracts/src/contracts/events/onDeploymentUpdated.ts
+++ b/contracts/orchestrator-contracts/src/contracts/events/onDeploymentUpdated.ts
@@ -1,0 +1,18 @@
+import { EventBridgeContract } from '@swarmion/serverless-contracts';
+
+export const onDeploymentUpdatedContract = new EventBridgeContract({
+  id: 'orchestrator-onDeploymentUpdated',
+  eventType: 'UPDATED_DEPLOYMENT',
+  sources: ['swarmion.orchestrator'] as const,
+  payloadSchema: {
+    type: 'object',
+    properties: {
+      serviceId: { type: 'string' },
+      applicationId: { type: 'string' },
+      eventId: { type: 'string' },
+      status: { type: 'string' },
+    },
+    required: ['serviceId', 'applicationId', 'eventId', 'status'],
+    additionalProperties: false,
+  } as const,
+});

--- a/nx.json
+++ b/nx.json
@@ -77,20 +77,36 @@
       "dependsOn": ["^package"]
     },
     "test-unit": {
-      "inputs": ["default", "^production"],
+      "inputs": [
+        "default",
+        "^production",
+        { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true }
+      ],
       "dependsOn": ["^package"],
       "outputs": ["{projectRoot}/coverage"]
     },
     "test-type": {
-      "inputs": ["default", "^production"],
+      "inputs": [
+        "default",
+        "^production",
+        { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true }
+      ],
       "dependsOn": ["^package"]
     },
     "test-circular": {
-      "inputs": ["default", "^production"],
+      "inputs": [
+        "default",
+        "^production",
+        { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true }
+      ],
       "dependsOn": ["^package"]
     },
     "test-integration": {
-      "inputs": ["default", "^production"],
+      "inputs": [
+        "default",
+        "^production",
+        { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true }
+      ],
       "dependsOn": ["^package"]
     }
   },

--- a/packages/serverless-contracts/src/contracts/eventBridge/__tests__/multiplelambdaHandler.test.ts
+++ b/packages/serverless-contracts/src/contracts/eventBridge/__tests__/multiplelambdaHandler.test.ts
@@ -1,0 +1,250 @@
+import Ajv from 'ajv';
+
+import { getHandlerContextMock } from '__mocks__/requestContext';
+
+import { EventBridgeContract } from '../eventBridgeContract';
+import { getMultipleEventBridgeHandler } from '../features';
+
+const ajv = new Ajv({ keywords: ['faker'] });
+
+describe('Multiple EventBridgeContract handler test', () => {
+  const eventBridgeContract = new EventBridgeContract({
+    id: 'myAwesomeEventBridgeContract',
+    sources: ['toto.tata'] as const,
+    eventType: 'MY_DETAIL_TYPE',
+    payloadSchema: {
+      type: 'object',
+      properties: { userId: { type: 'string' } },
+      required: ['userId'],
+      additionalProperties: false,
+    } as const,
+  });
+  const baseEvent = {
+    'detail-type': 'MY_DETAIL_TYPE' as const,
+    id: 'splof',
+    account: '111111',
+    version: '',
+    time: '',
+    region: '',
+    resources: [],
+    source: 'toto.tata' as const,
+  };
+  const eventBridgeContract2 = new EventBridgeContract({
+    id: 'myAwesomeEventBridgeContract',
+    sources: ['toto.tata.2'] as const,
+    eventType: 'MY_DETAIL_TYPE_2',
+    payloadSchema: {
+      type: 'object',
+      properties: { userId: { type: 'string' }, otherKey: { type: 'string' } },
+      required: ['userId'],
+      additionalProperties: false,
+    } as const,
+  });
+  const baseEvent2 = {
+    'detail-type': 'MY_DETAIL_TYPE_2' as const,
+    id: 'splof',
+    account: '111111',
+    version: '',
+    time: '',
+    region: '',
+    resources: [],
+    source: 'toto.tata.2' as const,
+  };
+  const fakeContext = getHandlerContextMock();
+
+  it('should validate the payload', async () => {
+    const handler = getMultipleEventBridgeHandler(
+      [eventBridgeContract, eventBridgeContract2],
+      {
+        ajv,
+      },
+    )(async event => {
+      await Promise.resolve();
+
+      return event.detail.userId;
+    });
+
+    const result = await handler(
+      {
+        ...baseEvent,
+        detail: { userId: 'toto' },
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toBe('toto');
+
+    const result2 = await handler(
+      {
+        ...baseEvent2,
+        detail: { userId: 'toto', otherKey: 'otherValue' },
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result2).toBe('toto');
+  });
+
+  it('should throw it the payload is invalid', async () => {
+    const handler = getMultipleEventBridgeHandler(
+      [eventBridgeContract, eventBridgeContract2],
+      {
+        ajv,
+      },
+    )(async event => {
+      await Promise.resolve();
+
+      return event.detail.userId;
+    });
+
+    await expect(
+      handler(
+        {
+          ...baseEvent,
+          // @ts-expect-error this is a test
+          detail: { tata: 'toto' },
+        },
+        fakeContext,
+        () => null,
+      ),
+    ).rejects.toThrowError();
+  });
+
+  it('should not throw it the payload is invalid but validation is disabled in options', async () => {
+    const handler = getMultipleEventBridgeHandler(
+      [eventBridgeContract, eventBridgeContract2],
+      {
+        validatePayload: false,
+      },
+    )(async event => {
+      await Promise.resolve();
+
+      return event.detail;
+    });
+
+    const result = await handler(
+      {
+        ...baseEvent,
+        // @ts-expect-error this is a test
+        detail: { tata: 'toto' },
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toEqual({ tata: 'toto' });
+
+    const result2 = await handler(
+      {
+        ...baseEvent2,
+        // @ts-expect-error this is a test
+        detail: { tata: 'toto' },
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result2).toEqual({ tata: 'toto' });
+  });
+
+  it('should accept additional arguments', async () => {
+    const mockSideEffect = vitest.fn(() => 'tata');
+    interface SideEffects {
+      mySideEffect: () => string;
+    }
+
+    const sideEffects = { mySideEffect: mockSideEffect };
+
+    const handler = getMultipleEventBridgeHandler(
+      [eventBridgeContract, eventBridgeContract2],
+      {
+        ajv,
+      },
+    )(async (
+      event,
+      _context,
+      _callback,
+      { mySideEffect }: SideEffects = sideEffects,
+    ) => {
+      await Promise.resolve();
+
+      const sideEffectRes = mySideEffect();
+
+      return `${event.detail.userId}-${sideEffectRes}`;
+    });
+
+    const result = await handler(
+      {
+        ...baseEvent,
+        detail: { userId: 'toto' },
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result).toBe('toto-tata');
+    expect(mockSideEffect).toHaveBeenCalledOnce();
+
+    vi.resetAllMocks();
+    const result2 = await handler(
+      {
+        ...baseEvent2,
+        detail: { userId: 'toto' },
+      },
+      fakeContext,
+      () => null,
+    );
+    expect(result2).toBe('toto-tata');
+    expect(mockSideEffect).toHaveBeenCalledOnce();
+  });
+
+  it('should allow overriding of additional arguments', async () => {
+    const mockSideEffect = vitest.fn(() => 'blob');
+    const mockUnusedSideEffect = vitest.fn(() => 'tata');
+    interface SideEffects {
+      mySideEffect: () => string;
+    }
+
+    const handler = getMultipleEventBridgeHandler(
+      [eventBridgeContract, eventBridgeContract2],
+      {
+        ajv,
+      },
+    )(async (
+      event,
+      _context,
+      _callback,
+      { mySideEffect }: SideEffects = { mySideEffect: mockUnusedSideEffect },
+    ) => {
+      await Promise.resolve();
+
+      const sideEffectRes = mySideEffect();
+
+      return `${event.detail.userId}-${sideEffectRes}`;
+    });
+
+    const result = await handler(
+      {
+        ...baseEvent,
+        detail: { userId: 'toto' },
+      },
+      fakeContext,
+      () => null,
+      { mySideEffect: mockSideEffect },
+    );
+    expect(result).toBe('toto-blob');
+    expect(mockSideEffect).toHaveBeenCalledOnce();
+    expect(mockUnusedSideEffect).toHaveBeenCalledTimes(0);
+
+    vi.resetAllMocks();
+    const result2 = await handler(
+      {
+        ...baseEvent2,
+        detail: { userId: 'toto' },
+      },
+      fakeContext,
+      () => null,
+      { mySideEffect: mockSideEffect },
+    );
+    expect(result2).toBe('toto-blob');
+    expect(mockSideEffect).toHaveBeenCalledOnce();
+    expect(mockUnusedSideEffect).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/serverless-contracts/src/contracts/eventBridge/features/index.ts
+++ b/packages/serverless-contracts/src/contracts/eventBridge/features/index.ts
@@ -3,3 +3,4 @@ export * from './fullContractSchema';
 export * from './lambdaHandler';
 export * from './putEvent';
 export * from './putEvents';
+export * from './multipleLambdaHandler';

--- a/packages/serverless-contracts/src/contracts/eventBridge/features/multipleLambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/eventBridge/features/multipleLambdaHandler.ts
@@ -1,0 +1,70 @@
+import Ajv, { ValidateFunction } from 'ajv';
+import type { EventBridgeEvent } from 'aws-lambda';
+
+import { EventBridgeContract } from '../eventBridgeContract';
+import {
+  ContractEventBridgeEvent,
+  EventBridgeMultipleHandler,
+  SwarmionEventBridgeMultipleHandler,
+} from '../types/lambdaHandler';
+
+export type GetMultipleEventBridgeHandlerOptions =
+  | {
+      ajv: Ajv;
+      validatePayload?: boolean;
+    }
+  | {
+      ajv?: Ajv;
+      validatePayload: false;
+    };
+
+const defaultOptions = {
+  validatePayload: true,
+};
+
+export const getMultipleEventBridgeHandler =
+  <
+    Contracts extends EventBridgeContract[],
+    Events extends EventBridgeEvent<string, unknown> = ContractEventBridgeEvent<
+      Contracts[number]
+    >,
+  >(
+    contracts: Contracts,
+    options: GetMultipleEventBridgeHandlerOptions,
+  ) =>
+  <AdditionalArgs extends unknown[] = []>(
+    handler: SwarmionEventBridgeMultipleHandler<Events, AdditionalArgs>,
+  ): EventBridgeMultipleHandler<Events, AdditionalArgs> => {
+    const { validatePayload, ajv } = { ...defaultOptions, ...options };
+
+    let payloadValidator: ValidateFunction | undefined = undefined;
+    if (validatePayload) {
+      payloadValidator = ajv.compile({
+        anyOf: contracts.map(contract => contract.payloadSchema),
+      });
+    }
+
+    return async (
+      event,
+      context,
+      callback,
+      ...additionalArgs: AdditionalArgs
+    ) => {
+      if (payloadValidator !== undefined) {
+        if (!payloadValidator(event.detail)) {
+          console.error('Error: Invalid payload');
+          console.error(JSON.stringify(payloadValidator.errors, null, 2));
+          throw new Error('Invalid payload');
+        }
+      }
+
+      const handlerResponse = await handler(
+        event,
+        context,
+        callback,
+        ...additionalArgs,
+      );
+
+      return handlerResponse;
+    };
+  };

--- a/packages/serverless-contracts/src/contracts/eventBridge/index.ts
+++ b/packages/serverless-contracts/src/contracts/eventBridge/index.ts
@@ -1,8 +1,16 @@
 export { EventBridgeContract } from './eventBridgeContract';
 export {
   getEventBridgeHandler,
+  getMultipleEventBridgeHandler,
   getEventBridgeTrigger,
   buildPutEvent,
   buildPutEvents,
 } from './features';
-export type * from './types';
+
+export type {
+  EventBridgeHandler,
+  SwarmionEventBridgeHandler,
+  EventBridgePayloadType,
+} from './types';
+
+export type { EventBridgeEvent } from 'aws-lambda';

--- a/packages/serverless-contracts/src/contracts/eventBridge/types/common.ts
+++ b/packages/serverless-contracts/src/contracts/eventBridge/types/common.ts
@@ -10,3 +10,7 @@ export type EventBridgePayloadType<Contract extends EventBridgeContract> =
 
 export type EventBridgeEvent<Contract extends EventBridgeContract> =
   AwsEventBridgeEvent<Contract['eventType'], EventBridgePayloadType<Contract>>;
+
+export type EventBridgePayloadUnionType<
+  Contracts extends EventBridgeContract[],
+> = EventBridgePayloadType<Contracts[number]>;

--- a/packages/serverless-contracts/src/contracts/eventBridge/types/lambdaHandler.ts
+++ b/packages/serverless-contracts/src/contracts/eventBridge/types/lambdaHandler.ts
@@ -3,7 +3,11 @@ import {
   Callback,
   Context,
   EventBridgeEvent,
+  Handler,
 } from 'aws-lambda';
+
+import { EventBridgePayloadType } from './common';
+import { EventBridgeContract } from '../eventBridgeContract';
 
 /**
  * The type of a Swarmion handler, with type-inferred event
@@ -20,6 +24,21 @@ export type SwarmionEventBridgeHandler<
   ...additionalArgs: AdditionalArgs
 ) => Promise<unknown>;
 
+export type ContractEventBridgeEvent<Contract extends EventBridgeContract> =
+  Contract extends EventBridgeContract
+    ? EventBridgeEvent<Contract['eventType'], EventBridgePayloadType<Contract>>
+    : never;
+
+export type SwarmionEventBridgeMultipleHandler<
+  Events extends EventBridgeEvent<string, unknown>,
+  AdditionalArgs extends unknown[],
+> = (
+  event: Events,
+  context: Context,
+  callback?: Callback,
+  ...additionalArgs: AdditionalArgs
+) => Promise<unknown>;
+
 /**
  * a simple helper type to build EventBridgeHandler
  */
@@ -27,6 +46,10 @@ type EventBridgeHandlerParameters<
   EventType extends string,
   Payload,
 > = Parameters<AwsLambdaEventBridgeHandler<EventType, Payload, unknown>>;
+
+type EventBridgeHandlerMultipleParameters<
+  Events extends EventBridgeEvent<string, unknown>,
+> = Parameters<Handler<Events, unknown>>;
 
 /**
  * The type of an EventBridge handler. This is the actual version that will
@@ -42,5 +65,15 @@ export type EventBridgeHandler<
   event: EventBridgeHandlerParameters<EventType, Payload>[0],
   context: EventBridgeHandlerParameters<EventType, Payload>[1],
   callback: EventBridgeHandlerParameters<EventType, Payload>[2],
+  ...additionalArgs: AdditionalArgs
+) => Promise<unknown>;
+
+export type EventBridgeMultipleHandler<
+  Events extends EventBridgeEvent<string, unknown>,
+  AdditionalArgs extends unknown[],
+> = (
+  event: EventBridgeHandlerMultipleParameters<Events>[0],
+  context: EventBridgeHandlerMultipleParameters<Events>[1],
+  callback: EventBridgeHandlerMultipleParameters<Events>[2],
   ...additionalArgs: AdditionalArgs
 ) => Promise<unknown>;

--- a/services/orchestrator/functions/onDeploymentRequested/config.ts
+++ b/services/orchestrator/functions/onDeploymentRequested/config.ts
@@ -1,4 +1,7 @@
-import { onDeploymentRequestedContract } from '@swarmion/orchestrator-contracts';
+import {
+  onDeploymentRequestedContract,
+  onDeploymentUpdatedContract,
+} from '@swarmion/orchestrator-contracts';
 import { getTrigger } from '@swarmion/serverless-contracts';
 import { getHandlerPath, LambdaFunction } from '@swarmion/serverless-helpers';
 
@@ -10,6 +13,9 @@ const config: LambdaFunction = {
   iamRoleStatementsInherit: true,
   events: [
     getTrigger(onDeploymentRequestedContract, {
+      eventBus: getCdkProperty('eventBusName'),
+    }),
+    getTrigger(onDeploymentUpdatedContract, {
       eventBus: getCdkProperty('eventBusName'),
     }),
   ],

--- a/services/orchestrator/functions/onDeploymentRequested/handler.ts
+++ b/services/orchestrator/functions/onDeploymentRequested/handler.ts
@@ -1,14 +1,18 @@
-import { onDeploymentRequestedContract } from '@swarmion/orchestrator-contracts';
-import { getHandler } from '@swarmion/serverless-contracts';
+import {
+  onDeploymentRequestedContract,
+  onDeploymentUpdatedContract,
+} from '@swarmion/orchestrator-contracts';
+import { getMultipleEventBridgeHandler } from '@swarmion/serverless-contracts';
 
 import { ajv } from 'libs/ajv';
 
-export const main = getHandler(onDeploymentRequestedContract, { ajv })(
-  async event => {
-    const { applicationId, eventId, serviceId } = event.detail;
+export const main = getMultipleEventBridgeHandler(
+  [onDeploymentRequestedContract, onDeploymentUpdatedContract],
+  { ajv },
+)(async event => {
+  const { applicationId, eventId, serviceId } = event.detail;
 
-    await Promise.resolve();
+  await Promise.resolve();
 
-    console.log({ applicationId, eventId, serviceId });
-  },
-);
+  console.log({ applicationId, eventId, serviceId });
+});

--- a/services/orchestrator/serverless.ts
+++ b/services/orchestrator/serverless.ts
@@ -3,6 +3,7 @@ import { AWS } from '@serverless/typescript';
 import {
   listDeploymentsContract,
   onDeploymentRequestedContract,
+  onDeploymentUpdatedContract,
   requestSyncDeploymentContract,
 } from '@swarmion/orchestrator-contracts';
 import { ServerlessCdkPluginConfig } from '@swarmion/serverless-cdk-plugin';
@@ -49,7 +50,7 @@ const serverlessConfiguration: AWS &
       listDeploymentsContract,
       onDeploymentRequestedContract,
     },
-    consumes: { onDeploymentRequestedContract },
+    consumes: { onDeploymentRequestedContract, onDeploymentUpdatedContract },
   },
   resources: {
     Description: 'Monorepo deployments orchestrator',


### PR DESCRIPTION
# Feature

`getMultipleEventBridgeHandler` util that can receive multiple EventBridge contracts at once (example in `services/orchestrator/functions/onDeploymentRequested/handler.ts`)

## Tech

This feature was present in `v0.33.0-alpha.2` which has been used for more than a year in production on at least one Theodo project (it works great and is very useful for us)

It is directly taken from Sc0ra's branch `feat/multiple-eventbridge-handler` ([commits visible here](https://github.com/swarmion/swarmion/compare/main...feat/multiple-eventbridge-handler))

I only cherry-picked d4ab0ae9b10f28425aed52dddd1620f16fc24951 since all other commits contain version bumping changes.

## Release

Please tell me how I can help you release this properly :slightly_smiling_face: 



# Second commit

Fixes mistaken cache hits from NX which previously did not consider that `pnpm run package` could modify some outputs.

As you can see, lint/unit tests failed [here](https://cloud.nx.app/runs/9uODgoJKh9/task/orchestrator%3Atest-type) but did not fail with this change (nor did they fail locally with `--skip-nx-cache`) because cache hit/miss is computed too early. [Doc is here](https://nx.dev/reference/inputs#outputs-of-dependent-tasks)

No idea why SonarCloud fails though